### PR TITLE
Add Postgres support in Typo Migrator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ task :default => :test
 namespace :migrate do
   desc "Migrate from mephisto in the current directory"
   task :mephisto do
-    sh %q(ruby -r './lib/jekyll/migrators/mephisto' -e 'Jekyll::Mephisto.postgres(:database => "#{ENV["DB"]}")')
+    sh %q(ruby -r './lib/jekyll/migrators/mephisto' -e 'Jekyll::Mephisto.postgres(:database => "#{ENV["SERVER"]}", "#{ENV["DB"]}")')
   end
   desc "Migrate from Movable Type in the current directory"
   task :mt do

--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -32,5 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('sequel', "~> 3.42")
   s.add_development_dependency('htmlentities', "~> 4.3")
   s.add_development_dependency('hpricot', "~> 0.8")
+  s.add_development_dependency('mysql', "~> 2.8")
+  s.add_development_dependency('pg', "~> 0.12")
   
 end

--- a/lib/jekyll/importers/typo.rb
+++ b/lib/jekyll/importers/typo.rb
@@ -6,8 +6,7 @@ require 'safe_yaml'
 
 module Jekyll
   module Typo
-    # This SQL *should* work for both MySQL and PostgreSQL, but I haven't
-    # tested PostgreSQL yet (as of 2008-12-16).
+    # This SQL *should* work for both MySQL and PostgreSQL.
     SQL = <<-EOS
     SELECT c.id id,
            c.title title,
@@ -21,9 +20,16 @@ module Jekyll
                         ON c.text_filter_id = tf.id
     EOS
 
-    def self.process dbname, user, pass, host='localhost'
+    def self.process server, dbname, user, pass, host='localhost'
       FileUtils.mkdir_p '_posts'
-      db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+      case server.intern
+      when :postgres
+        db = Sequel.postgres(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+      when :mysql
+        db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+      else
+        raise "Unknown database server '#{server}'"
+      end
       db[SQL].each do |post|
         next unless post[:state] =~ /published/
 


### PR DESCRIPTION
@joeyates made this in https://github.com/mojombo/jekyll/pull/375:

> The patch adds a 'SERVER' parameter, indicating type of database (for now just MySQL or postgres) and loads the Sequel driver accordingly.
> 
> I've also added the sequel, mysql and pg gems as development dependencies.
