### PR TITLE
Fixes YAML encoding in wordpress migration.

### DIFF
--- a/lib/jekyll/importers/wordpress.rb
+++ b/lib/jekyll/importers/wordpress.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'sequel'
 require 'fileutils'
+require 'psych'
 require 'safe_yaml'
 
 # NOTE: This converter requires Sequel and the MySQL gems.


### PR DESCRIPTION
@tjun filed this in https://github.com/mojombo/jekyll/pull/645 as a fix for a YAML encoding error.

It reportedly fixes https://github.com/mojombo/jekyll/issues/644.
