### PR TITLE
Fix for S9Y import

### DIFF
--- a/lib/jekyll/jekyll-import/s9y.rb
+++ b/lib/jekyll/jekyll-import/s9y.rb
@@ -12,11 +12,21 @@ require 'yaml'
 
 module JekyllImport
   module S9Y
-    def self.process(file_name)
+    def self.validate(options)
+      if !options[:source]
+        abort "Missing mandatory option --source, e.g. --source \"http://blog.example.com/rss.php?version=2.0&all=1\""
+      end
+    end
+
+    def self.process(options)
+      validate(options)
+
       FileUtils.mkdir_p("_posts")
 
+      source = options[:source]
+
       text = ''
-      open(file_name, 'r') { |line| text = line.read }
+      open(source) { |line| text = line.read }
       rss = RSS::Parser.parse(text)
 
       rss.items.each do |item|


### PR DESCRIPTION
I tried to use the S9Y import as-is and got the following error: `error: can't convert Hash into String`

It seems the file name wasn't being passed in as the code was expecting. I modeled a fix after the RSS import,  to use the `--source` argument. That will also allow flexibility to add an option to import comments.
