### PR TITLE
Fix wordpress import, since the input format seems to have changed

### DIFF
--- a/lib/jekyll/jekyll-import/wordpress.rb
+++ b/lib/jekyll/jekyll-import/wordpress.rb
@@ -50,9 +50,13 @@ module JekyllImport
     #                   and :revision. If this is nil or an empty
     #                   array, all posts are migrated regardless of
     #                   status. Default: [:publish].
-    # 
-    def self.process(dbname, user, pass, host='localhost', options={})
+    #
+    def self.process(options={})
       options = {
+        :user           => '',
+        :pass           => '',
+        :host           => 'localhost',
+        :dbname         => '',
         :table_prefix   => 'wp_',
         :clean_entities => true,
         :comments       => true,
@@ -75,8 +79,8 @@ module JekyllImport
 
       FileUtils.mkdir_p("_posts")
 
-      db = Sequel.mysql(dbname, :user => user, :password => pass,
-                        :host => host, :encoding => 'utf8')
+      db = Sequel.mysql(options[:dbname], :user => options[:user], :password => options[:pass],
+                        :host => options[:host], :encoding => 'utf8')
 
       px = options[:table_prefix]
 


### PR DESCRIPTION
The main "import" command method invokes the importer like this:

```
klass.process(options.__hash__)
```

Since the wordpress importer expecting separate parameters for dbname, user, ..., the import mechanism broke. Note that this fix only works with a Jekyll version where mojombo/jekyll#910 has been applied, since the import command is completely broken for me otherwise.
