### PR TITLE
Using the old mysql driver results in broken YAML frontmatters

### DIFF
--- a/lib/jekyll/jekyll-import/wordpress.rb
+++ b/lib/jekyll/jekyll-import/wordpress.rb
@@ -75,7 +75,7 @@ module JekyllImport
 
       FileUtils.mkdir_p("_posts")
 
-      db = Sequel.mysql(dbname, :user => user, :password => pass,
+      db = Sequel.mysql2(dbname, :user => user, :password => pass,
                         :host => host, :encoding => 'utf8')
 
       px = options[:table_prefix]


### PR DESCRIPTION
When using the old mysql driver, the returned string data always
seems to have a ASCII-8BIT encoding. `to_yaml` however expects all
strings to be UTF-8, and if they are not, encodes them as if they were
binary, which in turn breaks the Jekyll site generation (breaks in the
sense that category names are all garbled, for example)

Reference for the mysql driver behaviour:
http://stackoverflow.com/q/14070281/124257
