### PR TITLE
Update wordpressdotcom.rb to use its method parameter correctly.

### DIFF
--- a/lib/jekyll/jekyll-import/wordpressdotcom.rb
+++ b/lib/jekyll/jekyll-import/wordpressdotcom.rb
@@ -10,7 +10,7 @@ module JekyllImport
   # This importer takes a wordpress.xml file, which can be exported from your
   # wordpress.com blog (/wp-admin/export.php).
   module WordpressDotCom
-    def self.process(filename = "wordpress.xml")
+    def self.process(filename = {:source => "wordpress.xml"})
       import_count = Hash.new(0)
       doc = Hpricot::XML(File.read(filename[:source]))
 


### PR DESCRIPTION
When invoked from the command line using `jekyll import wordpressdotcom -s $FILENAME`, the `filename` argument being passed in to WordpressDotCom::process() is not a simple string. It is instead a Hash, and as such the method's dying on line 15. This patch fixes the error.
