### PR TITLE
Use native Ruby libs to convert HTML to text - Issue #32

### DIFF
--- a/lib/jekyll/jekyll-import/tumblr.rb
+++ b/lib/jekyll/jekyll-import/tumblr.rb
@@ -146,7 +146,7 @@ module JekyllImport
         content.gsub!(/<#{tag}/i, "$$" + tag)
         content.gsub!(/<\/#{tag}/i, "||" + tag)
       end
-      content = %x[echo '#{content.gsub("'", "''")}' | html2text]
+      content = Nokogiri::HTML(content.gsub("'", "''")).text
       preserve.each do |tag|
         content.gsub!("$$" + tag, "<" + tag)
         content.gsub!("||" + tag, "</" + tag)


### PR DESCRIPTION
Attempt to close Issue https://github.com/jekyll/jekyll-import/issues/32
