### PR TITLE
Add importer for cached Google Reader RSS feeds

### DIFF
--- a/lib/jekyll/commands/import.rb
+++ b/lib/jekyll/commands/import.rb
@@ -10,6 +10,7 @@ module Jekyll
         :drupal7 => 'Drupal7',
         :enki => 'Enki',
         :joomla => 'Joomla',
+        :google_reader => 'GoogleReader',
         :marley => 'Marley',
         :mephisto => 'Mephisto',
         :mt => 'MT',

--- a/lib/jekyll/jekyll-import/google_reader.rb
+++ b/lib/jekyll/jekyll-import/google_reader.rb
@@ -1,0 +1,61 @@
+# Usage:
+#   (Local file)
+#   ruby -r 'jekyll/jekyll-import/rss' -e "JekyllImport::GoogleReader.process(:source => './somefile/on/your/computer.xml')"
+
+require 'rss'
+require 'open-uri'
+require 'fileutils'
+require 'safe_yaml'
+
+require 'rexml/document'
+require 'date'
+
+module JekyllImport
+  module GoogleReader
+    def self.validate(options)
+      if !options[:source]
+        abort "Missing mandatory option --source."
+      end
+    end
+
+    # Process the import.
+    #
+    # source - a URL or a local file String.
+    #
+    # Returns nothing.
+    def self.process(options)
+      validate(options)
+
+      source = options[:source]
+
+      open(source) do |content|
+        feed = RSS::Parser.parse(content)
+
+        raise "There doesn't appear to be any RSS items at the source (#{source}) provided." unless feed
+
+        feed.items.each do |item|
+          title = item.title.content.to_s
+          formatted_date = Date.parse(item.published.to_s)
+          post_name = title.split(%r{ |!|/|:|&|-|$|,}).map do |i|
+            i.downcase if i != ''
+          end.compact.join('-')
+          name = "#{formatted_date}-#{post_name}" 
+
+          header = {
+            'layout' => 'post',
+            'title' => title
+          }
+
+          FileUtils.mkdir_p("_posts")
+
+          File.open("_posts/#{name}.html", "w") do |f|
+            f.puts header.to_yaml
+            f.puts "---\n\n"
+            f.puts item.content.content.to_s
+          end
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Google Reader is going bye-bye tomorrow, so I rushed to write something that could import posts from their cached RSS feeds (they look like "https://www.google.com/reader/atom/feed/$ENCODED_FEED_URL").

Not sure how much use this will be after tomorrow, but I hear the Archive Team is collecting these feed URLs for as many blogs as they can. So perhaps someone might have a need for this importer in the future? Figure it can't hurt. :)
