### PR TITLE
Fix Drupal 7 migrations

### DIFF
--- a/lib/jekyll/jekyll-import/drupal7.rb
+++ b/lib/jekyll/jekyll-import/drupal7.rb
@@ -22,7 +22,8 @@ module JekyllImport
              FROM node AS n, \
                   field_data_body AS fdb \
              WHERE (n.type = 'blog' OR n.type = 'story') \
-             AND n.vid = fdb.entity_id"
+             AND n.nid = fdb.entity_id \
+             AND n.vid = fdb.revision_id"
 
     def self.process(dbname, user, pass, host = 'localhost', prefix = '')
       db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')


### PR DESCRIPTION
The SQL command in the Drupal 7 migration script does not work as expected. `n.vid` refers to the revision of a node, while `fdb.entity_id` refers to the id of the node itself. Instead `fdb.entity_id` should be compared to `n.nid`. I've added another constraint to only use the current revision of each node.
