### PR TITLE
Removing custom slug code

### DIFF
--- a/lib/jekyll/jekyll-import/tumblr.rb
+++ b/lib/jekyll/jekyll-import/tumblr.rb
@@ -110,8 +110,7 @@ module JekyllImport
       end
       date = Date.parse(post['date']).to_s
       title = Nokogiri::HTML(title).text
-      slug = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
-      slug = slug.slice(0..200) if slug.length > 200
+      slug = post["slug"]
       {
         :name => "#{date}-#{slug}.#{format}",
         :header => {


### PR DESCRIPTION
The custom slug code is error prone and can create wrong entries like:

2011-12-03-ruby-on-rails---easy-setup-on-ubuntu.md

Where the correct is:

2011-12-03-ruby-on-rails-easy-setup-on-ubuntu.md

It also avoids huge photo captions to be used as the file name like in my case below:

2013-07-04-george-turned-2-today-thats-an-automatic-post-from-tumblr-i-will-also-use-to-inform-the-belowim-on-my-way-out-tumblr-going-into-jekyll-direction-migration-is-in-progress-and-it-should-be-completed-soon.md

With my change the above becomes:

2013-07-04-george-turned-2-today-thats-an-automatic-post.md

@parkr: Sorry I was not able to isolate my commits again. I did something wrong with my feature branch and hope to get it right in the next time.

Thanks,
George.
