### PR TITLE
Fix prefix replacement for drupal6

### DIFF
--- a/lib/jekyll/jekyll-import/drupal6.rb
+++ b/lib/jekyll/jekyll-import/drupal6.rb
@@ -33,6 +33,8 @@ module JekyllImport
       if prefix != ''
         QUERY[" node "] = " " + prefix + "node "
         QUERY[" node_revisions "] = " " + prefix + "node_revisions "
+        QUERY[" term_node "] = " " + prefix + "term_node "
+        QUERY[" term_data "] = " " + prefix + "term_data "
       end
 
       FileUtils.mkdir_p "_posts"


### PR DESCRIPTION
I wasn't able to import from my drupal6 installation which had a custom prefix. This fixes it. With this change, the import script works.

I verified that the drupal7 migration doesn't suffer from the same issues.
