### PR TITLE
Fix drupal6-to-jekyll migrations

### DIFF
--- a/lib/jekyll/jekyll-import/drupal6.rb
+++ b/lib/jekyll/jekyll-import/drupal6.rb
@@ -18,7 +18,7 @@ module JekyllImport
                     nr.body, \
                     n.created, \
                     n.status, \
-                    GROUP_CONCAT( td.name SEPARATOR ',' ) AS 'tags' \
+                    GROUP_CONCAT( td.name SEPARATOR '|' ) AS 'tags' \
                FROM node_revisions AS nr, \
                     node AS n \
                LEFT OUTER JOIN term_node AS tn ON tn.nid = n.nid \
@@ -59,8 +59,7 @@ EOF
         node_id = post[:nid]
         title = post[:title]
         content = post[:body]
-        tags = ''
-        tags = post[:tags].downcase.strip unless post[:tags].nil?
+        tags = post.fetch(:tags, '').downcase.strip
         created = post[:created]
         time = Time.at(created)
         is_published = post[:status] == 1
@@ -74,7 +73,7 @@ EOF
            'layout' => 'post',
            'title' => title.to_s,
            'created' => created,
-           'categories' => tags.split(',')
+           'categories' => tags.split('|')
          }.delete_if { |k,v| v.nil? || v == ''}.each_pair {
             |k,v| ((v.is_a? String) ? v.force_encoding("UTF-8") : v)
          }.to_yaml


### PR DESCRIPTION
This addresses issues 2 and 3 as identified in https://github.com/jekyll/jekyll-import/commit/0b33a12ae5b1fa6b793414fbeb4bf44388516177#commitcomment-3631300

Instead of manually serializing the tags/categories list as a string ourselves, we leave it as an array and let to_yaml handle the serialization.

I tested this on my drupal installation with posts that contain tags that contain and don't contain spaces, and with posts that contain and don't contain tags. 
