### PR TITLE
Create _layouts/ before writing refresh.html

### DIFF
--- a/lib/jekyll/jekyll-import/drupal6.rb
+++ b/lib/jekyll/jekyll-import/drupal6.rb
@@ -39,6 +39,7 @@ module JekyllImport
 
       FileUtils.mkdir_p "_posts"
       FileUtils.mkdir_p "_drafts"
+      FileUtils.mkdir_p "_layouts"
 
       # Create the refresh layout
       # Change the refresh url if you customized your permalink config

--- a/lib/jekyll/jekyll-import/drupal7.rb
+++ b/lib/jekyll/jekyll-import/drupal7.rb
@@ -35,6 +35,7 @@ module JekyllImport
 
       FileUtils.mkdir_p "_posts"
       FileUtils.mkdir_p "_drafts"
+      FileUtils.mkdir_p "_layouts"
 
       db[QUERY].each do |post|
         # Get required fields and construct Jekyll compatible name


### PR DESCRIPTION
Took me a second to realize the Drupal import was expecting the `_layouts` directory to already exist. I went ahead and created the directory manually and rolled the patch after the fact:

```
$ ruby -rubygems -e 'require "jekyll/jekyll-import/drupal6";
    JekyllImport::Drupal6.process("dbname", "user", "pass")'
/home/amorton/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-import-0.1.0.beta3/lib/jekyll/jekyll-import/drupal6.rb:45:in `initialize': No such file or directory - _layouts/refresh.html (Errno::ENOENT)
  from /home/amorton/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-import-0.1.0.beta3/lib/jekyll/jekyll-import/drupal6.rb:45:in `open'
  from /home/amorton/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-import-0.1.0.beta3/lib/jekyll/jekyll-import/drupal6.rb:45:in `process'
  from -e:2:in `<main>'
$ ls -la
total 16
drwxrwxr-x  4 amorton amorton 4096 Aug 11 16:29 ./
drwxr-xr-x 26 amorton amorton 4096 Aug 11 16:21 ../
drwxrwxr-x  2 amorton amorton 4096 Aug 11 16:29 _drafts/
drwxrwxr-x  2 amorton amorton 4096 Aug 11 16:29 _posts/
$ mkdir _layouts
$ ruby -rubygems -e 'require "jekyll/jekyll-import/drupal6";
    JekyllImport::Drupal6.process("dbname", "user", "pass")'
$
```

Which generated a bunch of files... I'll go make sure they're all correct next ;)
