### PR TITLE
Fix the Drupal code comments

### DIFF
--- a/lib/jekyll/jekyll-import/drupal6.rb
+++ b/lib/jekyll/jekyll-import/drupal6.rb
@@ -12,7 +12,7 @@ require 'safe_yaml'
 module JekyllImport
   module Drupal6
     # Reads a MySQL database via Sequel and creates a post file for each story
-    # and blog node in table node.
+    # and blog node.
     QUERY = "SELECT n.nid, \
                     n.title, \
                     nr.body, \
@@ -105,8 +105,6 @@ EOF
 
       # TODO: Make dirs & files for nodes of type 'page'
         # Make refresh pages for these as well
-
-      # TODO: Make refresh dirs & files according to entries in url_alias table
     end
   end
 end

--- a/lib/jekyll/jekyll-import/drupal7.rb
+++ b/lib/jekyll/jekyll-import/drupal7.rb
@@ -11,9 +11,8 @@ require 'yaml'
 
 module JekyllImport
   module Drupal7
-    # Reads a MySQL database via Sequel and creates a post file for each post
-    # in wp_posts that has post_status = 'publish'. This restriction is made
-    # because 'draft' posts are not guaranteed to have valid dates.
+    # Reads a MySQL database via Sequel and creates a post file for each story
+    # and blog node.
     QUERY = "SELECT n.nid, \
                     n.title, \
                     fdb.body_value, \


### PR DESCRIPTION
Had some comments left from when the code started in the WordPress migrator.
The Drupal 6 version creates refresh files for the url_alias so no need for
a TODO.
