### PR TITLE
Correcting the homepage URL so links from rubygems.org will work

### DIFF
--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.authors  = ["Tom Preston-Werner"]
   s.email    = 'tom@mojombo.com'
-  s.homepage = 'http://github.com/mojombo/jekyll-import'
+  s.homepage = 'http://github.com/jekyll/jekyll-import'
 
   s.require_paths = %w[lib]
 


### PR DESCRIPTION
The homepage link currently on https://rubygems.org/gems/jekyll-import goes to https://github.com/mojombo/jekyll-import, which 404s.
