### PR TITLE
Update version of safe_yaml to ~> 0.9.7 to be compatible with Jekyll v1.3

### DIFF
--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
-  s.add_runtime_dependency('jekyll', '~> 1.0')
+  s.add_runtime_dependency('jekyll', '~> 1.3')
   s.add_runtime_dependency('fastercsv')
   s.add_runtime_dependency('nokogiri')
   s.add_runtime_dependency('safe_yaml', '~> 0.9.7')


### PR DESCRIPTION
https://github.com/mojombo/jekyll/issues/1685
