### PR TITLE
Match Joomla and WordPress importers with the rest

### DIFF
--- a/lib/jekyll/jekyll-import/joomla.rb
+++ b/lib/jekyll/jekyll-import/joomla.rb
@@ -12,7 +12,7 @@ require 'safe_yaml'
 
 module JekyllImport
   module Joomla
-    def self.process(dbname, user, pass, host = 'localhost', table_prefix = 'jos_', section = '1')
+    def self.process(dbname, user, pass, host = 'localhost', prefix = 'jos_', section = '1')
       db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
       FileUtils.mkdir_p("_posts")

--- a/lib/jekyll/jekyll-import/wordpress.rb
+++ b/lib/jekyll/jekyll-import/wordpress.rb
@@ -16,15 +16,15 @@ module JekyllImport
   module WordPress
 
     # Main migrator function. Call this to perform the migration.
-    # 
+    #
     # dbname::  The name of the database
     # user::    The database user name
     # pass::    The database user's password
     # host::    The address of the MySQL database host. Default: 'localhost'
     # options:: A hash table of configuration options.
-    # 
+    #
     # Supported options are:
-    # 
+    #
     # :table_prefix::   Prefix of database tables used by WordPress.
     #                   Default: 'wp_'
     # :clean_entities:: If true, convert non-ASCII characters to HTML
@@ -59,7 +59,7 @@ module JekyllImport
         :pass           => '',
         :host           => 'localhost',
         :dbname         => '',
-        :table_prefix   => 'wp_',
+        :prefix         => 'wp_',
         :clean_entities => true,
         :comments       => true,
         :categories     => true,
@@ -155,7 +155,7 @@ module JekyllImport
         if options[:more_anchor]
           more_link = "more"
           content.sub!(/<!-- *more *-->/,
-                       "<a id=\"more\"></a>" + 
+                       "<a id=\"more\"></a>" +
                        "<a id=\"more-#{post[:id]}\"></a>")
         end
       end


### PR DESCRIPTION
Change the "table_prefix" option to "prefix" so it matches the rest of the importers. This change is needed to make it work with the jekyll import command line (--prefix) option.
