### PR TITLE
Change 'story' to 'article'

### DIFF
--- a/lib/jekyll/jekyll-import/drupal7.rb
+++ b/lib/jekyll/jekyll-import/drupal7.rb
@@ -20,7 +20,7 @@ module JekyllImport
                     n.status \
              FROM node AS n, \
                   field_data_body AS fdb \
-             WHERE (n.type = 'blog' OR n.type = 'article') \
+             WHERE (n.type = 'blog' OR n.type = 'story' OR n.type = 'article') \
              AND n.nid = fdb.entity_id \
              AND n.vid = fdb.revision_id"
 


### PR DESCRIPTION
In Drupal 7 the content type 'story' changed to 'article'. You can't really rely on the blog content type always being the same on every Drupal install. It might be worth making the content type and option.
