### PR TITLE
Fixes wordpress importer and require path error.

### DIFF
--- a/lib/jekyll-import/importers/wordpress.rb
+++ b/lib/jekyll-import/importers/wordpress.rb
@@ -75,18 +75,18 @@ module JekyllImport
       #
       def self.process(opts)
         options = {
-          :user           => opts.fetch('user', ''),
-          :pass           => opts.fetch('password', ''),
-          :host           => opts.fetch('host', 'localhost'),
-          :dbname         => opts.fetch('dbname', ''),
-          :table_prefix   => opts.fetch('prefix', 'wp_'),
-          :clean_entities => opts.fetch('clean_entities', true),
-          :comments       => opts.fetch('comments', true),
-          :categories     => opts.fetch('categories', true),
-          :tags           => opts.fetch('tags', true),
-          :more_excerpt   => opts.fetch('more_excerpt', true),
-          :more_anchor    => opts.fetch('more_anchor', true),
-          :status         => opts.fetch('status', ["publish"]).map(&:to_sym) # :draft, :private, :revision
+          :user           => opts.fetch(:user, ''),
+          :pass           => opts.fetch(:pass, ''),
+          :host           => opts.fetch(:host, 'localhost'),
+          :dbname         => opts.fetch(:dbname, ''),
+          :table_prefix   => opts.fetch(:prefix, 'wp_'),
+          :clean_entities => opts.fetch(:clean_entities, true),
+          :comments       => opts.fetch(:comments, true),
+          :categories     => opts.fetch(:categories, true),
+          :tags           => opts.fetch(:tags, true),
+          :more_excerpt   => opts.fetch(:more_excerpt, true),
+          :more_anchor    => opts.fetch(:more_anchor, true),
+          :status         => opts.fetch(:status, ["publish"]).map(&:to_sym) # :draft, :private, :revision
         }
 
         if options[:clean_entities]
@@ -98,7 +98,6 @@ module JekyllImport
             options[:clean_entities] = false
           end
         end
-
         FileUtils.mkdir_p("_posts")
 
         db = Sequel.mysql2(options[:dbname], :user => options[:user], :password => options[:pass],

--- a/lib/jekyll/commands/import.rb
+++ b/lib/jekyll/commands/import.rb
@@ -37,10 +37,11 @@ module Jekyll
         if IMPORTERS.keys.include?(migrator.to_s.to_sym)
           migrator = migrator.to_s.downcase
 
-          require File.join(File.dirname(__FILE__), "..", "jekyll-import", "#{migrator}.rb")
+          require File.join(File.dirname(__FILE__), "..", "..", "jekyll-import", "importers", "#{migrator}.rb")
 
-          if JekyllImport.const_defined?(IMPORTERS[migrator.to_sym])
-            klass = JekyllImport.const_get(IMPORTERS[migrator.to_sym])
+          if JekyllImport::Importers.const_defined?(IMPORTERS[migrator.to_sym])
+            klass = JekyllImport::Importers.const_get(IMPORTERS[migrator.to_sym])
+            klass.require_deps
             klass.validate(options.__hash__) if klass.respond_to?(:validate)
             puts 'Importing...'
             klass.process(options.__hash__)


### PR DESCRIPTION
The import command was using the wrong path for the location of
importers. Also fixes the option keys in the WordPress importer.
The importer was incorrectly fetching the keys as strings instead of
symbols. The others importers will still need to be updated.
