### PR TITLE
Require yaml lib in enki importer

### DIFF
--- a/lib/jekyll-import/importers/enki.rb
+++ b/lib/jekyll-import/importers/enki.rb
@@ -35,6 +35,7 @@ EOS
           sequel
           fileutils
           pg
+          yaml
         ])
       end
 


### PR DESCRIPTION
Fixes "undefined method 'to_yaml' for <#Hash..>" error
