### PR TITLE
import wordpress.com posts as .md files

### DIFF
--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -54,7 +54,7 @@ module JekyllImport
             metas[key] = value;
           end
 
-          name = "#{date.strftime('%Y-%m-%d')}-#{permalink_title}.html"
+          name = "#{date.strftime('%Y-%m-%d')}-#{permalink_title}.md"
           header = {
             'layout' => type,
             'title'  => title,


### PR DESCRIPTION
Using wordpressdotcom importer imports posts as .html files but formats entires as markdown. This causes inconsistencies during the migration (eg. erases newlines). Changing the file extension to .md fixes this. 
