### PR TITLE
Drupal6: Ensure post "tags" is "", never nil

### DIFF
--- a/lib/jekyll-import/importers/drupal6.rb
+++ b/lib/jekyll-import/importers/drupal6.rb
@@ -87,7 +87,7 @@ EOF
           node_id = post[:nid]
           title = post[:title]
           content = post[:body]
-          tags = post.fetch(:tags, '').downcase.strip
+          tags = (post[:tags] || '').downcase.strip
           created = post[:created]
           time = Time.at(created)
           is_published = post[:status] == 1


### PR DESCRIPTION
Tags should default to an empty string, whether the value exists or is
nil/false.

Fixes #115.
