### PR TITLE
Change Drupal7 layout to `post`

### DIFF
--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -78,7 +78,7 @@ module JekyllImport
           # Get the relevant fields as a hash, delete empty fields and convert
           # to YAML for the header
           data = {
-             'layout' => 'default',
+             'layout' => 'post',
              'title' => title.to_s,
              'created' => created,
            }.delete_if { |k,v| v.nil? || v == ''}.to_yaml


### PR DESCRIPTION
Every other importer either sets `layout: post` or prompts the user in some way to set the layout.

Drupal 7 should do the same.
