### PR TITLE
Support auto-paragraph wordpress convention

### DIFF
--- a/lib/jekyll-import.rb
+++ b/lib/jekyll-import.rb
@@ -6,6 +6,7 @@ require 'colorator'
 
 require 'jekyll-import/importer'
 require 'jekyll-import/importers'
+require 'jekyll-import/util'
 
 module JekyllImport
   VERSION = '0.1.0'

--- a/lib/jekyll-import/importers/wordpress.rb
+++ b/lib/jekyll-import/importers/wordpress.rb
@@ -286,7 +286,7 @@ module JekyllImport
         File.open("_posts/#{name}", "w") do |f|
           f.puts data
           f.puts "---"
-          f.puts content
+          f.puts Util.wpautop(content)
         end
       end
 

--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -71,7 +71,7 @@ module JekyllImport
             File.open("_#{type}s/#{name}", "w") do |f|
               f.puts header.to_yaml
               f.puts '---'
-              f.puts item.at('content:encoded').inner_text
+              f.puts Util.wpautop(item.at('content:encoded').inner_text)
             end
           rescue => e
             puts "Couldn't import post!"

--- a/lib/jekyll-import/util.rb
+++ b/lib/jekyll-import/util.rb
@@ -1,0 +1,76 @@
+module JekyllImport
+  module Util
+
+    # Ruby translation of wordpress wpautop (see https://core.trac.wordpress.org/browser/trunk/src/wp-includes/formatting.php)
+    #
+    # A group of regex replaces used to identify text formatted with newlines and
+    # replace double line-breaks with HTML paragraph tags. The remaining
+    # line-breaks after conversion become <<br />> tags, unless $br is set to false
+    #
+    # @param string pee The text which has to be formatted.
+    # @param bool br Optional. If set, this will convert all remaining line-breaks after paragraphing. Default true.
+    # @return string Text which has been converted into correct paragraph tags.
+    #
+    def self.wpautop(pee, br = true)
+      return '' if pee.strip == ''
+
+      allblocks = '(?:table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre|select|option|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|noscript|legend|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary)'
+      pre_tags = {}
+      pee = pee + "\n"
+
+      if pee.include?('<pre')
+        pee_parts = pee.split('</pre>')
+        last_pee = pee_parts.pop
+        pee = ''
+        pee_parts.each_with_index do |pee_part, i|
+          start = pee_part.index('<pre')
+
+          unless start
+            pee += pee_part
+            continue
+          end
+
+          name = "<pre wp-pre-tag-#{i}></pre>"
+          pre_tags[name] = pee_part[start..-1] + '</pre>'
+
+          pee += pee_part[0, start] + name
+        end
+        pee += last_pee
+      end
+
+      pee = pee.gsub(Regexp.new('<br />\s*<br />'), "\n\n")
+      pee = pee.gsub(Regexp.new("(<" + allblocks + "[^>]*>)"), "\n\\1")
+      pee = pee.gsub(Regexp.new("(</" + allblocks + ">)"), "\\1\n\n")
+      pee = pee.gsub("\r\n", "\n").gsub("\r", "\n")
+      if pee.include? '<object'
+        pee = pee.gsub(Regexp.new('\s*<param([^>]*)>\s*'), "<param\\1>")
+        pee = pee.gsub(Regexp.new('\s*</embed>\s*'), '</embed>')
+      end
+
+      pees = pee.split(/\n\s*\n/).compact
+      pee = ''
+      pees.each { |tinkle| pee += '<p>' + tinkle.chomp("\n") + "</p>\n" }
+      pee = pee.gsub(Regexp.new('<p>\s*</p>'), '')
+      pee = pee.gsub(Regexp.new('<p>([^<]+)</(div|address|form)>'), "<p>\\1</p></\\2>")
+      pee = pee.gsub(Regexp.new('<p>\s*(</?' + allblocks + '[^>]*>)\s*</p>'), "\\1")
+      pee = pee.gsub(Regexp.new('<p>(<li.+?)</p>'), "\\1")
+      pee = pee.gsub(Regexp.new('<p><blockquote([^>]*)>', 'i'), "<blockquote\\1><p>")
+      pee = pee.gsub('</blockquote></p>', '</p></blockquote>')
+      pee = pee.gsub(Regexp.new('<p>\s*(</?' + allblocks + '[^>]*>)'), "\\1")
+      pee = pee.gsub(Regexp.new('(</?' + allblocks + '[^>]*>)\s*</p>'), "\\1")
+      if br
+        pee = pee.gsub(Regexp.new('<(script|style).*?</\1>')) { |match| match.gsub("\n", "<WPPreserveNewline />") }
+        pee = pee.gsub(Regexp.new('(?<!<br />)\s*\n'), "<br />\n")
+        pee = pee.gsub('<WPPreserveNewline />', "\n")
+      end
+      pee = pee.gsub(Regexp.new('(</?' + allblocks + '[^>]*>)\s*<br />'), "\\1")
+      pee = pee.gsub(Regexp.new('<br />(\s*</?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)[^>]*>)'), "\\1")
+      pee = pee.gsub(Regexp.new('\n</p>$'), '</p>')
+
+      pre_tags.each do |name, value|
+        pee.gsub!(name, value)
+      end
+      pee
+    end
+  end
+end

--- a/test/test_util.rb
+++ b/test/test_util.rb
@@ -1,0 +1,10 @@
+require 'helper'
+
+class TestUtil < Test::Unit::TestCase
+
+  should ".wpautop (wordpress auto-paragraphs)" do
+    original = "this is a test\n<p>and it works</p>"
+    expected = "<p>this is a test</p>\n<p>and it works</p>\n"
+    assert_equal(expected, Util.wpautop(original))
+  end
+end


### PR DESCRIPTION
This PR fixes #107

I have migrated the nasty [wpautop](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/formatting.php#L202) helper to ruby in order to import posts as they are rendered in wordpress (i.e. with automatic paragraph wrapping)
