### PR TITLE
Added clarification to Wordpress doc

### DIFF
--- a/site/docs/wordpress.md
+++ b/site/docs/wordpress.md
@@ -7,6 +7,8 @@ next_section: wordpressdotcom
 permalink: /docs/wordpress/
 ---
 
+This importer only converts your posts and creates YAML front-matter. It does not import any layouts, styling, or external files (images, CSS, etc.).
+
 To import your posts from a self-hosted [WordPress](http://wordpress.org)
 installation, run:
 


### PR DESCRIPTION
This is my first pull request. There is no reason you have to accept it but please let me know if I did it wrong.

Maybe my hopes were too high but I was expecting this importer to do more than something like "thomasf/exitwp".  It didn't.  If the docs were more clear, I never would have attempted installing it. So this is my attempt at clarifying the docs.
