### PR TITLE
WordPress import error 

### DIFF
--- a/lib/jekyll-import/util.rb
+++ b/lib/jekyll-import/util.rb
@@ -27,7 +27,7 @@ module JekyllImport
 
           unless start
             pee += pee_part
-            continue
+            next
           end
 
           name = "<pre wp-pre-tag-#{i}></pre>"


### PR DESCRIPTION
Hi, I was importing a blog directly from the db and I'm getting this error in jekyll-import version 0.2.0. This is not happening with version 0.1.0.

``` sh
error: undefined local variable or method `continue' for JekyllImport::Util:Module. Use --trace to view backtrace
```

This error occurs with both commands:

``` sh
$ jekyll import wordpress --dbname my-wp-db --user root --prefix wp_
```

and

``` sh
$ ruby -rubygems -e 'require "jekyll-import"; JekyllImport::Importers::WordPress.run({"dbname" => "my-wp-db", "user" => "root", "password" => "", "prefix" => "wp_", "comments" => false })'
```

I've changed the `continue` with `next` and everything seems to be working just fine. 
