### PR TITLE
WordpressDotCom importer doesn't emit date header

### DIFF
--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -108,6 +108,7 @@ module JekyllImport
           header = {
             'layout' => type,
             'title'  => title,
+            'date' => date,
             'categories' => categories,
             'tags'   => tags,
             'status'   => status,


### PR DESCRIPTION
Emit the exact post time in YAML header when importing from a wordpress.xml file so that the exact time at which posts are published won't be lost.

This is particularly important for blog authors who want to produce WordPress compatible RSS/RDF feeds as some clients treat posts with different publishing time as different posts.
