### PR TITLE
Using nil for wordpress default socket

### DIFF
--- a/lib/jekyll-import/importers/wordpress.rb
+++ b/lib/jekyll-import/importers/wordpress.rb
@@ -72,7 +72,7 @@ module JekyllImport
           :user           => opts.fetch('user', ''),
           :pass           => opts.fetch('password', ''),
           :host           => opts.fetch('host', 'localhost'),
-          :socket         => opts.fetch('socket', ''),
+          :socket         => opts.fetch('socket', nil),
           :dbname         => opts.fetch('dbname', ''),
           :table_prefix   => opts.fetch('table_prefix', 'wp_'),
           :clean_entities => opts.fetch('clean_entities', true),


### PR DESCRIPTION
This PR is to fix issue #161 for jekyll-import. The default socket of an empty string causes issues while passing nil as a default does not. 

I could not come up with an automated test for this as we'd need a test db to use Sequel with. You can recreate this issue on command line with an error occuring pre-PR with:

``` bash
ruby -rubygems -e 'require "jekyll-import";
  JekyllImport::Importers::WordPress.run({
  "dbname" => "your_db",
  "user" => "root"
})'
```

Using the change in the PR the above will work.
