### PR TITLE
(Tumblr) Add nil check to prevent undefined method error (fixes #29)

### DIFF
--- a/lib/jekyll-import/importers/tumblr.rb
+++ b/lib/jekyll-import/importers/tumblr.rb
@@ -131,8 +131,12 @@ module JekyllImport
           when "video"
             title = post["video-title"]
             content = post["video-player"]
-            unless content.nil? || post["video-caption"].nil?
-              content << "<br/>" + post["video-caption"]
+            unless post["video-caption"].nil?
+              unless content.nil?
+                content << "<br/>" + post["video-caption"]
+              else
+                content = post["video-caption"]
+              end
             end
           when "answer"
             title = post["question"]

--- a/lib/jekyll-import/importers/tumblr.rb
+++ b/lib/jekyll-import/importers/tumblr.rb
@@ -133,7 +133,7 @@ module JekyllImport
             content = post["video-player"]
             unless content.nil? || post["video-caption"].nil?
               content << "<br/>" + post["video-caption"]
-            end              
+            end
           when "answer"
             title = post["question"]
             content = post["answer"]

--- a/lib/jekyll-import/importers/tumblr.rb
+++ b/lib/jekyll-import/importers/tumblr.rb
@@ -131,8 +131,10 @@ module JekyllImport
           when "video"
             title = post["video-title"]
             content = post["video-player"]
-            unless post["video-caption"].nil?
-              content << "<br/>" + post["video-caption"]
+            unless post[:content].nil?
+              unless post["video-caption"].nil?
+                content << "<br/>" + post["video-caption"]
+              end              
             end
           when "answer"
             title = post["question"]

--- a/lib/jekyll-import/importers/tumblr.rb
+++ b/lib/jekyll-import/importers/tumblr.rb
@@ -131,11 +131,9 @@ module JekyllImport
           when "video"
             title = post["video-title"]
             content = post["video-player"]
-            unless post[:content].nil?
-              unless post["video-caption"].nil?
-                content << "<br/>" + post["video-caption"]
-              end              
-            end
+            unless content.nil? || post["video-caption"].nil?
+              content << "<br/>" + post["video-caption"]
+            end              
           when "answer"
             title = post["question"]
             content = post["answer"]


### PR DESCRIPTION
Fix for this error when importing a Tumblr blog with video posts with empty `video-player` field:

```
Fetching http://paramaggarwal.com/api/read/json/?num=50&start=0
Page: 1 - Posts: 50
/usr/local/lib/ruby/gems/2.2.0/gems/jekyll-import-0.5.3/lib/jekyll-import/importers/tumblr.rb:136:in `post_to_hash': undefined method `<<' for false:FalseClass (NoMethodError)
	from /usr/local/lib/ruby/gems/2.2.0/gems/jekyll-import-0.5.3/lib/jekyll-import/importers/tumblr.rb:47:in `block in process'
	from /usr/local/lib/ruby/gems/2.2.0/gems/jekyll-import-0.5.3/lib/jekyll-import/importers/tumblr.rb:47:in `map'
	from /usr/local/lib/ruby/gems/2.2.0/gems/jekyll-import-0.5.3/lib/jekyll-import/importers/tumblr.rb:47:in `process'
	from /usr/local/lib/ruby/gems/2.2.0/gems/jekyll-import-0.5.3/lib/jekyll-import/importer.rb:23:in `run'
	from -e:2:in `<main>'
```