### PR TITLE
Joomla importer

### DIFF
--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -24,7 +24,6 @@ module JekyllImport
           sequel
           fileutils
           safe_yaml
-          unidecode
         ])
       end
 
@@ -84,7 +83,7 @@ module JekyllImport
 
       # Borrowed from the Wordpress importer
       def self.sluggify( title )
-        title = title.to_ascii.downcase.gsub(/[^0-9A-Za-z]+/, " ").strip.gsub(" ", "-")
+        title = title.downcase.gsub(/[^0-9A-Za-z]+/, " ").strip.gsub(" ", "-")
       end
     end
   end

--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -24,6 +24,7 @@ module JekyllImport
           sequel
           fileutils
           safe_yaml
+          unidecode
         ])
       end
 
@@ -47,9 +48,18 @@ module JekyllImport
         db[query].each do |post|
           # Get required fields and construct Jekyll compatible name.
           title = post[:title]
-          slug = post[:alias]
           date = post[:created]
           content = post[:content]
+
+          # Construct a slug from the title if alias field empty.
+          # Remove illegal filename characters.
+          if !post[:alias] or post[:alias].empty?
+            slug = sluggify(post[:title])
+          else
+            slug = sluggify(post[:alias])
+          end
+
+	  
           name = "%02d-%02d-%02d-%s.markdown" % [date.year, date.month, date.day,
                                                  slug]
 
@@ -70,6 +80,11 @@ module JekyllImport
             f.puts content
           end
         end
+      end
+
+      # Borrowed from the Wordpress importer
+      def self.sluggify( title )
+        title = title.to_ascii.downcase.gsub(/[^0-9A-Za-z]+/, " ").strip.gsub(" ", "-")
       end
     end
   end

--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -59,7 +59,6 @@ module JekyllImport
             slug = sluggify(post[:alias])
           end
 
-	  
           name = "%02d-%02d-%02d-%03d-%s.markdown" % [date.year, date.month, date.day,
                                                  id,slug]
 

--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -42,7 +42,7 @@ module JekyllImport
         # Reads a MySQL database via Sequel and creates a post file for each
         # post in wp_posts that has post_status = 'publish'. This restriction is
         # made because 'draft' posts are not guaranteed to have valid dates.
-        query = "SELECT `title`, `alias`, CONCAT(`introtext`,`fulltext`) as content, `created`, `id` FROM #{table_prefix}content WHERE state = '0' OR state = '1' AND sectionid = '#{section}'"
+        query = "SELECT `title`, `alias`, CONCAT(`introtext`,`fulltext`) as content, `created`, `id` FROM #{table_prefix}content WHERE (state = '0' OR state = '1') AND sectionid = '#{section}'"
 
         db[query].each do |post|
           # Get required fields and construct Jekyll compatible name.

--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -49,6 +49,7 @@ module JekyllImport
           title = post[:title]
           date = post[:created]
           content = post[:content]
+          id = post[:id]
 
           # Construct a slug from the title if alias field empty.
           # Remove illegal filename characters.
@@ -59,8 +60,8 @@ module JekyllImport
           end
 
 	  
-          name = "%02d-%02d-%02d-%s.markdown" % [date.year, date.month, date.day,
-                                                 slug]
+          name = "%02d-%02d-%02d_%03d_%s.markdown" % [date.year, date.month, date.day,
+                                                 id,slug]
 
           # Get the relevant fields as a hash, delete empty fields and convert
           # to YAML for the header.

--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -60,7 +60,7 @@ module JekyllImport
           end
 
 	  
-          name = "%02d-%02d-%02d_%03d_%s.markdown" % [date.year, date.month, date.day,
+          name = "%02d-%02d-%02d-%03d-%s.markdown" % [date.year, date.month, date.day,
                                                  id,slug]
 
           # Get the relevant fields as a hash, delete empty fields and convert


### PR DESCRIPTION
1. The importer was generating pages for articles outside the selected category.  Added parentheses so the proper precedence is enforced.
2. Joomla! article aliases are used to construct the filename as YYYY-MM-DD-alias.markdown.  Some aliases in the database I was importing were blank resulting in YYYY-MM-DD-.markdown filenames.  If more than one article was missing the alias and happened to be authored on the same day, each would overwrite the previous only leaving the last imported.  Using the title, when the alias was empty, resolved these conflicts.
3. Some aliases / titles contained characters that were illegal for filenames and the importer would terminate with an error when attempting to write the file.  Borrowed the sluggify method from the Wordpress importer to strip all illegal characters from the filename.

Note: I actually imported from Joomla 1.0.15.  The only difference is the field name "alias" in 1.5 is "title_alias" in 1.0.15.  I simply renamed the field (in an offline copy of the database) and the importer worked.