### PR TITLE
Add post excerpt to WordPress.com importer

### DIFF
--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -117,6 +117,11 @@ module JekyllImport
 
           begin
             content = Hpricot(item.at('content:encoded').inner_text)
+            excerpt = Hpricot(item.at('excerpt:encoded').inner_text)
+
+            if excerpt
+              header['excerpt'] = excerpt
+            end
 
             if fetch
               download_images(title, content, assets_folder)


### PR DESCRIPTION
Prior to this PR, the XML importer for WordPress.com would ignore the `post_excerpt` field. This is useful for SEO purposes (for the meta description in templates) as well as for other potential uses when displaying the content in a list view.