### PR TITLE
Fix Title extraction in Drupal 7 import script

### DIFF
--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -73,7 +73,8 @@ module JekyllImport
           # to YAML for the header
           data = {
             'layout' => 'post',
-            'title' => title.to_s,
+            'title' => title,
+            'permalink' => '/' + title.gsub(' ', /_/),
             'created' => created,
             'excerpt' => summary
           }.delete_if { |k,v| v.nil? || v == ''}.to_yaml

--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -73,8 +73,7 @@ module JekyllImport
           # to YAML for the header
           data = {
             'layout' => 'post',
-            'title' => title,
-            'permalink' => '/' + title.gsub(' ', /_/),
+            'title' => title.strip.force_encoding("UTF-8"),
             'created' => created,
             'excerpt' => summary
           }.delete_if { |k,v| v.nil? || v == ''}.to_yaml


### PR DESCRIPTION
As shown in this Github Issue: [Problem extracting titles from Drupal 7 site](https://github.com/jekyll/jekyll-import/issues/90), `drupal7.rb` dumps a binary mess in each post instead of the Title string.

```yaml
title: !binary |-
  SGVsbG8gV29ybGQ=
```

I have fixed this bug entirely by forcing the strings into Unicode format (and stripping any preceding and ending whitespace with `strip`):

```ruby
'title' => title.strip.force_encoding("UTF-8"),
```

That way, it works even for those  pesky titles with stray \xE2 junk that screws everything up.

Please merge this pull request to fix the Drupal 7 importer. Try it out.