### PR TITLE
Require all of rss when importing RSS feed.

### DIFF
--- a/lib/jekyll-import/importers/rss.rb
+++ b/lib/jekyll-import/importers/rss.rb
@@ -13,6 +13,7 @@ module JekyllImport
 
       def self.require_deps
         JekyllImport.require_with_fallback(%w[
+          rss
           rss/1.0
           rss/2.0
           open-uri


### PR DESCRIPTION
Otherwise it won't parse an Atom field.

Fixes #194.