### PR TITLE
Wordpress - Add Site Prefix 

### DIFF
--- a/lib/jekyll-import/importers/wordpress.rb
+++ b/lib/jekyll-import/importers/wordpress.rb
@@ -19,7 +19,7 @@ module JekyllImport
         c.option 'password', '--password PW', "Database user's password (default: "")"
         c.option 'host', '--host HOST', 'Database host name (default: "localhost")'
         c.option 'table_prefix', '--table_prefix PREFIX', 'Table prefix name (default: "wp_")'
-        c.option 'site_prefix', '--site_prefix PREFIX', 'Site prefix name (default: "2_")'
+        c.option 'site_prefix', '--site_prefix PREFIX', 'Site prefix name (default: "")'
         c.option 'clean_entities', '--clean_entities', 'Whether to clean entities (default: true)'
         c.option 'comments', '--comments', 'Whether to import comments (default: true)'
         c.option 'categories', '--categories', 'Whether to import categories (default: true)'
@@ -43,8 +43,8 @@ module JekyllImport
       # :table_prefix::   Prefix of database tables used by WordPress.
       #                   Default: 'wp_'
       # :site_prefix::    Prefix of database tables used by WordPress
-      #                   Multisite.
-      #                   Default: nil
+      #                   Multisite, eg: 2_.
+      #                   Default: ''
       # :clean_entities:: If true, convert non-ASCII characters to HTML
       #                   entities in the posts, comments, titles, and
       #                   names. Requires the 'htmlentities' gem to

--- a/lib/jekyll-import/importers/wordpress.rb
+++ b/lib/jekyll-import/importers/wordpress.rb
@@ -198,6 +198,7 @@ module JekyllImport
             excerpt = content[0...more_index]
           end
           if options[:more_anchor]
+            more_link = "more"
             content.sub!(/<!-- *more *-->/,
                          "<a id=\"more\"></a>" +
                          "<a id=\"more-#{post[:id]}\"></a>")

--- a/site/_importers/wordpress.md
+++ b/site/_importers/wordpress.md
@@ -26,6 +26,7 @@ $ ruby -rubygems -e 'require "jekyll-import";
       "host"     => "localhost",
       "socket"   => "",
       "table_prefix"   => "wp_",
+      "site_prefix"    => "",
       "clean_entities" => true,
       "comments"       => true,
       "categories"     => true,


### PR DESCRIPTION
I came across https://github.com/jekyll/jekyll-import/issues/185 when trying to import a multi site installation.

To give some background, the way that this installation has it configured, the sites are each stored as wp_x_ prefixes.

![screen shot 2015-06-24 at 12 07 44 am](https://cloud.githubusercontent.com/assets/81055/8341132/005719e8-1a91-11e5-9414-a1eb81a0dc06.png)

In order to support this I have added the `site-prefix` option which is prepended before all calls to these specific tables.

Import site `wp_2_`

```
ruby -rubygems -e 'require "jekyll-import";
  JekyllImport::Importers::WordPress.run({
    "dbname"      => "blogname",
    "user"        => "username",
    "password"    => "password",
    "host"        => "blog.com",
    "site_prefix" => "2_"
  })'
```