### PR TITLE
Fix #211, wordpressdotcom import assets URLs

### DIFF
--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -30,7 +30,7 @@ module JekyllImport
         images.each do |i|
           uri = i["src"]
 
-          i["src"] = assets_folder + "/" + File.basename(uri)
+          i["src"] = "{{ site.baseurl }}/%s/%s" % [assets_folder, File.basename(uri)]
           dst = File.join(assets_folder, File.basename(uri))
           puts "  " + uri
           if File.exist?(dst)


### PR DESCRIPTION
Currently URLs created for downloaded images in `assets_folder` are not prepended with slash therefore images are being linked as relative URLs i.e `/2012/03/16/assets/myimage.jpg` instead of the correct absolute ones `/assets/myimage.jpg`.

The fix also adds support for `site.baseurl` which means the images will also be linked correctly when serving site from custom base URL.

More info in [forums](https://talk.jekyllrb.com/t/importing-wordpress-xml-downloads-images-to-assets-but-urls-to-this-dont-work/986).