### PR TITLE
Correctly handle wordpressdotcom drafts

### DIFF
--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -71,16 +71,16 @@ module JekyllImport
           end
         ] rescue {}
 
-        (doc/:channel/:item).each do |item|
-          title = item.at(:title).inner_text.strip
-          permalink_title = item.at('wp:post_name').inner_text
+        (doc/:channel/:item).each do |node|
+          title = node.at(:title).inner_text.strip
+          permalink_title = node.at('wp:post_name').inner_text
           # Fallback to "prettified" title if post_name is empty (can happen)
           if permalink_title == ""
             permalink_title = sluggify(title)
           end
 
-          date = Time.parse(item.at('wp:post_date').inner_text)
-          status = item.at('wp:status').inner_text
+          date = Time.parse(node.at('wp:post_date').inner_text)
+          status = node.at('wp:status').inner_text
 
           if status == "publish"
             published = true
@@ -88,18 +88,18 @@ module JekyllImport
             published = false
           end
 
-          type = item.at('wp:post_type').inner_text
-          categories = item.search('category[@domain="category"]').map{|c| c.inner_text}.reject{|c| c == 'Uncategorized'}.uniq
-          tags = item.search('category[@domain="post_tag"]').map{|t| t.inner_text}.uniq
+          type = node.at('wp:post_type').inner_text
+          categories = node.search('category[@domain="category"]').map{|c| c.inner_text}.reject{|c| c == 'Uncategorized'}.uniq
+          tags = node.search('category[@domain="post_tag"]').map{|t| t.inner_text}.uniq
 
           metas = Hash.new
-          item.search("wp:postmeta").each do |meta|
+          node.search("wp:postmeta").each do |meta|
             key = meta.at('wp:meta_key').inner_text
             value = meta.at('wp:meta_value').inner_text
             metas[key] = value
           end
 
-          author_login = item.at('dc:creator').inner_text.strip
+          author_login = node.at('dc:creator').inner_text.strip
 
           name = "#{date.strftime('%Y-%m-%d')}-#{permalink_title}.html"
           header = {
@@ -116,8 +116,8 @@ module JekyllImport
           }
 
           begin
-            content = Hpricot(item.at('content:encoded').inner_text)
-            excerpt = Hpricot(item.at('excerpt:encoded').inner_text)
+            content = Hpricot(node.at('content:encoded').inner_text)
+            excerpt = Hpricot(node.at('excerpt:encoded').inner_text)
 
             if excerpt
               header['excerpt'] = excerpt

--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -70,7 +70,9 @@ module JekyllImport
         end
 
         def published_at
-          Time.parse(@node.at('wp:post_date').inner_text)
+          if published?
+            Time.parse(@node.at('wp:post_date').inner_text)
+          end
         end
 
         def status
@@ -82,11 +84,19 @@ module JekyllImport
         end
 
         def file_name
-          "#{published_at.strftime('%Y-%m-%d')}-#{permalink_title}.html"
+          if published?
+            "#{published_at.strftime('%Y-%m-%d')}-#{permalink_title}.html"
+          else
+            "#{permalink_title}.html"
+          end
         end
 
         def directory_name
-          "_#{post_type}s"
+          if !published? && post_type == 'post'
+            '_drafts'
+          else
+            "_#{post_type}s"
+          end
         end
 
         def published?

--- a/test/test_wordpressdotcom_importer.rb
+++ b/test/test_wordpressdotcom_importer.rb
@@ -6,3 +6,95 @@ class TestWordpressDotComMigrator < Test::Unit::TestCase
     assert_equal("blogs-part-1-2", Importers::WordpressDotCom.sluggify(test_title))
   end
 end
+
+class TestWordpressDotComItem < Test::Unit::TestCase
+  should "extract an item's title" do
+    node = Hpricot(%q{
+      <item>
+        <title>Dear Science</title>
+      </item>}).at('item')
+
+    item = Importers::WordpressDotCom::Item.new(node)
+    assert_equal('Dear Science', item.title)
+  end
+
+  should "use post_name for the permalink_title if it's there" do
+    node = Hpricot(%q{
+      <item>
+        <wp:post_name>cookie-mountain</wp:post_name>
+        <title>Dear Science</title>
+      </item>}).at('item')
+
+    item = Importers::WordpressDotCom::Item.new(node)
+    assert_equal('cookie-mountain', item.permalink_title)
+  end
+
+  should "sluggify title for the permalink_title if post_name is empty" do
+    node = Hpricot(%q{
+      <item>
+        <wp:post_name></wp:post_name>
+        <title>Dear Science</title>
+      </item>}).at('item')
+
+    item = Importers::WordpressDotCom::Item.new(node)
+    assert_equal('dear-science', item.permalink_title)
+  end
+end
+
+class TestWordpressDotComPublishedItem < TestWordpressDotComItem
+  def node
+    Hpricot(%q{
+      <item>
+        <wp:post_name>post-name</wp:post_name>
+        <wp:post_type>post</wp:post_type>
+        <wp:status>publish</wp:status>
+        <wp:post_date>2015-01-23 08:53:47</wp:post_date>
+      </item>}).at('item')
+  end
+  def item
+    Importers::WordpressDotCom::Item.new(node)
+  end
+
+  should "extract the date-time the item was published" do
+    assert_equal(Time.new(2015, 1, 23, 8, 53, 47), item.published_at)
+  end
+
+  should 'put the date in the file_name' do
+    assert_equal('2015-01-23-post-name.html', item.file_name)
+  end
+
+  should "put the file in ./_posts" do
+    assert_equal('_posts', item.directory_name)
+  end
+
+  should 'know its status' do
+    assert_equal('publish', item.status)
+  end
+
+  should 'be published' do
+    assert_equal(true, item.published?)
+  end
+end
+
+class TestWordpressDotComDraftItem < TestWordpressDotComItem
+  def node
+    Hpricot(%q{
+      <item>
+        <wp:post_name>post-name</wp:post_name>
+        <wp:post_type>post</wp:post_type>
+        <wp:status>draft</wp:status>
+        <wp:post_date>0000-00-00 00:00:00</wp:post_date>
+      </item>}).at('item')
+  end
+  def item
+    Importers::WordpressDotCom::Item.new(node)
+  end
+
+  should 'know its status' do
+    assert_equal('draft', item.status)
+  end
+
+  should 'not be published' do
+    assert_equal(false, item.published?)
+  end
+end

--- a/test/test_wordpressdotcom_importer.rb
+++ b/test/test_wordpressdotcom_importer.rb
@@ -90,6 +90,18 @@ class TestWordpressDotComDraftItem < TestWordpressDotComItem
     Importers::WordpressDotCom::Item.new(node)
   end
 
+  should "extract a nil publish-date" do
+    assert_equal(nil, item.published_at)
+  end
+
+  should 'not put the date in the file_name' do
+    assert_equal('post-name.html', item.file_name)
+  end
+
+  should "put the file in ./_drafts" do
+    assert_equal('_drafts', item.directory_name)
+  end
+
   should 'know its status' do
     assert_equal('draft', item.status)
   end


### PR DESCRIPTION
When importing an unpublished draft from wordpress.com, jekyll-import was raising an exception trying to parse its published date, which is set to `0000-00-00 00:00:00`. It was using this to prepend the publish-date to the filename in `./_posts`.

This pull request changes the WordpressDotCom import so that:
* it doesn't try to parse the zero dates
* it doesn't prepend the date to the filenames
* it stores drafts in `./_drafts` instead of `./_posts`

I also added a bunch of test coverage for the WordpressDotCom importer, mostly by pulling lots of logic into a separate class, `JekyllImport::Importers::WordpressDotCom::Item`, and constructing those with specific XML. The actual writing of files is still untested, but there's less going on there now.