### PR TITLE
Use `test-unit` gem if using a version of Ruby where it's been removed

### DIFF
--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rr', "~> 1.0")
   s.add_development_dependency('simplecov', "~> 0.7")
   s.add_development_dependency('simplecov-gem-adapter', "~> 1.0.1")
+  s.add_development_dependency('test-unit') if RUBY_VERSION > '2.1'
 
   # migrator dependencies:
   s.add_development_dependency('sequel', "~> 3.42")


### PR DESCRIPTION
The `Test::Unit` classes have been removed from Ruby 2.2. You can still use them via the [test-unit gem](https://rubygems.org/gems/test-unit).

This adds the test-unit gem to the Gemfile, if the current Ruby version is after 2.1, the last Ruby version test-unit shipped with.