### PR TITLE
Fix post-merge hiccups after #213

### DIFF
--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -106,6 +106,17 @@ module JekyllImport
         def published?
           @published ||= (status == 'publish')
         end
+
+        def excerpt
+          @excerpt ||= begin
+            text = Hpricot(text_for('excerpt:encoded')).inner_text
+            if text.empty?
+              nil
+            else
+              text
+            end
+          end
+        end
       end
 
       def self.process(options)
@@ -158,9 +169,7 @@ module JekyllImport
 
           begin
             content = Hpricot(item.text_for('content:encoded'))
-            excerpt = Hpricot(item.text_for('excerpt:encoded'))
-
-            header['excerpt'] = excerpt if excerpt && !excerpt.empty?
+            header['excerpt'] = item.excerpt if item.excerpt
 
             if fetch
               download_images(item.title, content, assets_folder)

--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -163,7 +163,7 @@ module JekyllImport
             header['excerpt'] = excerpt if excerpt && !excerpt.empty?
 
             if fetch
-              download_images(title, content, assets_folder)
+              download_images(item.title, content, assets_folder)
             end
 
             FileUtils.mkdir_p item.directory_name
@@ -174,13 +174,13 @@ module JekyllImport
             end
           rescue => e
             puts "Couldn't import post!"
-            puts "Title: #{title}"
+            puts "Title: #{item.title}"
             puts "Name/Slug: #{item.file_name}\n"
             puts "Error: #{e.message}"
             next
           end
 
-          import_count[type] += 1
+          import_count[item.post_type] += 1
         end
 
         import_count.each do |key, value|

--- a/test/test_wordpressdotcom_importer.rb
+++ b/test/test_wordpressdotcom_importer.rb
@@ -39,6 +39,26 @@ class TestWordpressDotComItem < Test::Unit::TestCase
     item = Importers::WordpressDotCom::Item.new(node)
     assert_equal('dear-science', item.permalink_title)
   end
+
+  should "return nil for the excerpt, if it's missing" do
+    node = Hpricot(%q{
+      <item>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+      </item>}).at('item')
+
+    item = Importers::WordpressDotCom::Item.new(node)
+    assert_equal(nil, item.excerpt)
+  end
+
+  should "extract the excerpt as plaintext, if it's present" do
+    node = Hpricot(%q{
+      <item>
+        <excerpt:encoded><![CDATA[...this one weird trick.]]></excerpt:encoded>
+      </item>}).at('item')
+
+    item = Importers::WordpressDotCom::Item.new(node)
+    assert_equal('...this one weird trick.', item.excerpt)
+  end
 end
 
 class TestWordpressDotComPublishedItem < TestWordpressDotComItem


### PR DESCRIPTION
It looks like there were some hiccups with the cleanup after merging #213:
* Some local variables were removed. This replaces their reference sites with calls to the appropriate Item methods.
* It was trying to call `.empty?` on an Hpricot::Doc, which doesn't support that method.
  * This also stops including empty excerpts in a Post's metadata.