### PR TITLE
now follows 'safe' http->https redirs for images

### DIFF
--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('jekyll', '>= 1.4')
   s.add_runtime_dependency('fastercsv')
   s.add_runtime_dependency('nokogiri')
+  s.add_runtime_dependency('open_uri_redirections')
 
   # development dependencies
   s.add_development_dependency('rake', "~> 10.1.0")

--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -11,6 +11,7 @@ module JekyllImport
           hpricot
           time
           open-uri
+          open_uri_redirections
         ])
       end
 
@@ -38,14 +39,15 @@ module JekyllImport
             next
           end
           begin
-            open(uri) {|f|
+            open(uri, allow_redirections: :safe) {|f|
               File.open(dst, "wb") do |out|
                 out.puts f.read
               end
             }
             puts "    OK!"
           rescue => e
-            puts "    Errorr: #{e.message}"
+            puts "    Error: #{e.message}"
+            puts e.backtrace.join("\n")
           end
         end
       end


### PR DESCRIPTION
The wordpress importer was failing to follow http->https redirections for my images (so it was failing to download them). This was due to open-uri not following these redirs.

Added the `open_uri_redirections` gem and changed the `open(uri)` call to:

``` ruby
open(uri, allow_redirections: :safe)
```

Also changed error logging method to say "Error" instead of "Errorr".