### PR TITLE
Wordpress Import Fails on Missing Method

### DIFF
--- a/lib/jekyll-import.rb
+++ b/lib/jekyll-import.rb
@@ -46,7 +46,8 @@ module JekyllImport
         logger.error "  2. Run 'bundle install'"
         logger.error ""
         logger.error "If you're not using bundler:"
-        logger.abort_with "  1. Run 'gem install #{gem}'."
+        logger.error "  1. Run 'gem install #{gem}'."
+        abort
       end
     end
   end


### PR DESCRIPTION
The logger does not have a "abort_with" method anymore, it was removed at https://github.com/jekyll/jekyll/commit/4a73e099b7504b1d81d96d9b395e185821516f14#diff-efe1f52fcde6ded7f3df13099f9e7c8c

I have removed the reference to this method.