### PR TITLE
Allow importing any Drupal 7 node type

### DIFF
--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -10,7 +10,7 @@ module JekyllImport
                       n.status \
                FROM node AS n, \
                     field_data_body AS fdb \
-               WHERE (n.type = 'blog' OR n.type = 'story' OR n.type = 'article') \
+               WHERE (%types%) \
                AND n.nid = fdb.entity_id \
                AND n.vid = fdb.revision_id"
 
@@ -28,6 +28,7 @@ module JekyllImport
         c.option 'password', '--password PW', 'Database user\'s password (default: "")'
         c.option 'host', '--host HOST', 'Database host name (default: "localhost")'
         c.option 'prefix', '--prefix PREFIX', 'Table prefix name'
+        c.option 'types', '--types TYPE1[,TYPE2[,TYPE3...]]', Array, 'The Drupal content types to be imported.'
       end
 
       def self.require_deps
@@ -45,6 +46,7 @@ module JekyllImport
         pass   = options.fetch('password', "")
         host   = options.fetch('host', "localhost")
         prefix = options.fetch('prefix', "")
+        types  = options.fetch('types', ['blog', 'story', 'article'])
 
         db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
@@ -52,6 +54,9 @@ module JekyllImport
           QUERY[" node "] = " " + prefix + "node "
           QUERY[" field_data_body "] = " " + prefix + "field_data_body "
         end
+
+        types = types.join("' OR n.type = '")
+        QUERY[" WHERE (%types%) "] = " WHERE (n.type = '#{types}') "
 
         FileUtils.mkdir_p "_posts"
         FileUtils.mkdir_p "_drafts"


### PR DESCRIPTION
This adds a `--types` command line option to allow the user to specify which node types to import from Drupal 7. This way the user can also import pages or any other content type.

It defaults to the ones the importer already did (blog posts, articles and stories), so that users are not forced to specify the node types and thus they won't see a difference if they don't need this ability.