### PR TITLE
Clean up the Drupal importers

### DIFF
--- a/lib/jekyll-import/importers/drupal6.rb
+++ b/lib/jekyll-import/importers/drupal6.rb
@@ -34,8 +34,8 @@ module JekyllImport
       end
 
       def self.get_data(post)
-        content = post[:body]
-        summary = post[:teaser]
+        content = post[:body].to_s
+        summary = post[:teaser].to_s
         tags = (post[:tags] || '').downcase.strip
 
         data = {

--- a/lib/jekyll-import/importers/drupal6.rb
+++ b/lib/jekyll-import/importers/drupal6.rb
@@ -38,8 +38,6 @@ module JekyllImport
         summary = post[:teaser]
         tags = (post[:tags] || '').downcase.strip
 
-        # Get the relevant fields as a hash, delete empty fields and convert
-        # to YAML for the header
         data = {
           :excerpt => summary,
           :categories => tags.split('|')

--- a/lib/jekyll-import/importers/drupal6.rb
+++ b/lib/jekyll-import/importers/drupal6.rb
@@ -41,8 +41,8 @@ EOS
         tags = (post[:tags] || '').downcase.strip
 
         data = {
-          :excerpt => summary,
-          :categories => tags.split('|')
+          'excerpt' => summary,
+          'categories' => tags.split('|')
         }
 
          return data, content

--- a/lib/jekyll-import/importers/drupal6.rb
+++ b/lib/jekyll-import/importers/drupal6.rb
@@ -10,21 +10,23 @@ module JekyllImport
         types = types.join("' OR n.type = '")
         types = "n.type = '#{types}'"
 
-        query = "SELECT n.nid, \
-                        n.title, \
-                        nr.body, \
-                        nr.teaser, \
-                        n.created, \
-                        n.status, \
-                        n.type, \
-                        GROUP_CONCAT( td.name SEPARATOR '|' ) AS 'tags' \
-                  FROM #{prefix}node_revisions AS nr, \
-                       #{prefix}node AS n \
-                  LEFT OUTER JOIN #{prefix}term_node AS tn ON tn.nid = n.nid \
-                  LEFT OUTER JOIN #{prefix}term_data AS td ON tn.tid = td.tid \
-                  WHERE (#{types}) \
-                    AND n.vid = nr.vid \
-                  GROUP BY n.nid"
+        query = <<EOS
+                SELECT n.nid,
+                       n.title,
+                       nr.body,
+                       nr.teaser,
+                       n.created,
+                       n.status,
+                       n.type,
+                       GROUP_CONCAT( td.name SEPARATOR '|' ) AS 'tags'
+                FROM #{prefix}node_revisions AS nr,
+                     #{prefix}node AS n
+                     LEFT OUTER JOIN #{prefix}term_node AS tn ON tn.nid = n.nid
+                     LEFT OUTER JOIN #{prefix}term_data AS td ON tn.tid = td.tid
+                WHERE (#{types})
+                  AND n.vid = nr.vid
+                GROUP BY n.nid
+EOS
 
         return query
       end

--- a/lib/jekyll-import/importers/drupal6.rb
+++ b/lib/jekyll-import/importers/drupal6.rb
@@ -1,139 +1,53 @@
+require 'jekyll-import/importers/drupal_common.rb'
+
 module JekyllImport
   module Importers
     class Drupal6 < Importer
-      # Reads a MySQL database via Sequel and creates a post file for each story
-      # and blog node.
-      QUERY = "SELECT n.nid, \
-                      n.title, \
-                      nr.body, \
-                      n.created, \
-                      n.status, \
-                      GROUP_CONCAT( td.name SEPARATOR '|' ) AS 'tags' \
-                 FROM node_revisions AS nr, \
-                      node AS n \
-                 LEFT OUTER JOIN term_node AS tn ON tn.nid = n.nid \
-                 LEFT OUTER JOIN term_data AS td ON tn.tid = td.tid \
-                WHERE (%types%) \
-                  AND n.vid = nr.vid \
-             GROUP BY n.nid"
+      include DrupalCommon
+      extend DrupalCommon::ClassMethods
 
-      def self.validate(options)
-        %w[dbname user].each do |option|
-          if options[option].nil?
-            abort "Missing mandatory option --#{option}."
-          end
-        end
-      end
-
-      def self.specify_options(c)
-        c.option 'dbname', '--dbname DB', 'Database name'
-        c.option 'user', '--user USER', 'Database user name'
-        c.option 'password', '--password PW', "Database user's password (default: '')"
-        c.option 'host', '--host HOST', 'Database host name (default: "localhost")'
-        c.option 'prefix', '--prefix PREFIX', 'Table prefix name'
-        c.option 'types', '--types TYPE1[,TYPE2[,TYPE3...]]', Array, 'The Drupal content types to be imported.'
-      end
-
-      def self.require_deps
-        JekyllImport.require_with_fallback(%w[
-          rubygems
-          sequel
-          fileutils
-          safe_yaml
-          mysql
-        ])
-      end
-
-      def self.process(options)
-        dbname = options.fetch('dbname')
-        user   = options.fetch('user')
-        pass   = options.fetch('password', "")
-        host   = options.fetch('host', "localhost")
-        prefix = options.fetch('prefix', "")
-        types  = options.fetch('types', ['blog', 'story', 'article'])
-
-        db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
-
-        if prefix != ''
-          QUERY[" node "] = " " + prefix + "node "
-          QUERY[" node_revisions "] = " " + prefix + "node_revisions "
-          QUERY[" term_node "] = " " + prefix + "term_node "
-          QUERY[" term_data "] = " " + prefix + "term_data "
-        end
-
+      def self.get_query(prefix, types)
         types = types.join("' OR n.type = '")
-        QUERY[" WHERE (%types%) "] = " WHERE (n.type = '#{types}') "
+        types = "n.type = '#{types}'"
 
-        FileUtils.mkdir_p "_posts"
-        FileUtils.mkdir_p "_drafts"
-        FileUtils.mkdir_p "_layouts"
+        query = "SELECT n.nid, \
+                        n.title, \
+                        nr.body, \
+                        nr.teaser, \
+                        n.created, \
+                        n.status, \
+                        n.type, \
+                        GROUP_CONCAT( td.name SEPARATOR '|' ) AS 'tags' \
+                  FROM #{prefix}node_revisions AS nr, \
+                       #{prefix}node AS n \
+                  LEFT OUTER JOIN #{prefix}term_node AS tn ON tn.nid = n.nid \
+                  LEFT OUTER JOIN #{prefix}term_data AS td ON tn.tid = td.tid \
+                  WHERE (#{types}) \
+                    AND n.vid = nr.vid \
+                  GROUP BY n.nid"
 
-        # Create the refresh layout
-        # Change the refresh url if you customized your permalink config
-        File.open("_layouts/refresh.html", "w") do |f|
-          f.puts <<EOF
-<!DOCTYPE html>
-<html>
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<meta http-equiv="refresh" content="0;url={{ page.refresh_to_post_id }}.html" />
-</head>
-</html>
-EOF
-        end
-
-        db[QUERY].each do |post|
-          # Get required fields and construct Jekyll compatible name
-          node_id = post[:nid]
-          title = post[:title]
-          content = post[:body]
-          tags = (post[:tags] || '').downcase.strip
-          created = post[:created]
-          time = Time.at(created)
-          is_published = post[:status] == 1
-          dir = is_published ? "_posts" : "_drafts"
-          slug = title.strip.downcase.gsub(/(&|&amp;)/, ' and ').gsub(/[\s\.\/\\]/, '-').gsub(/[^\w-]/, '').gsub(/[-_]{2,}/, '-').gsub(/^[-_]/, '').gsub(/[-_]$/, '')
-          name = time.strftime("%Y-%m-%d-") + slug + '.md'
-
-          # Get the relevant fields as a hash, delete empty fields and convert
-          # to YAML for the header
-          data = {
-             'layout' => 'post',
-             'title' => title.to_s,
-             'created' => created,
-             'categories' => tags.split('|')
-           }.delete_if { |k,v| v.nil? || v == ''}.each_pair {
-              |k,v| ((v.is_a? String) ? v.force_encoding("UTF-8") : v)
-           }.to_yaml
-
-          # Write out the data and content to file
-          File.open("#{dir}/#{name}", "w") do |f|
-            f.puts data
-            f.puts "---"
-            f.puts content
-          end
-
-          # Make a file to redirect from the old Drupal URL
-          if is_published
-            aliases = db["SELECT dst FROM #{prefix}url_alias WHERE src = ?", "node/#{node_id}"].all
-
-            aliases.push(:dst => "node/#{node_id}")
-
-            aliases.each do |url_alias|
-              FileUtils.mkdir_p url_alias[:dst]
-              File.open("#{url_alias[:dst]}/index.md", "w") do |f|
-                f.puts "---"
-                f.puts "layout: refresh"
-                f.puts "refresh_to_post_id: /#{time.strftime("%Y/%m/%d/") + slug}"
-                f.puts "---"
-              end
-            end
-          end
-        end
-
-        # TODO: Make dirs & files for nodes of type 'page'
-        # Make refresh pages for these as well
+        return query
       end
+
+      def self.get_aliases_query(prefix)
+        return "SELECT dst AS alias FROM #{prefix}url_alias WHERE src = ?"
+      end
+
+      def self.get_data(post)
+        content = post[:body]
+        summary = post[:teaser]
+        tags = (post[:tags] || '').downcase.strip
+
+        # Get the relevant fields as a hash, delete empty fields and convert
+        # to YAML for the header
+        data = {
+          :excerpt => summary,
+          :categories => tags.split('|')
+        }
+
+         return data, content
+      end
+
     end
   end
 end

--- a/lib/jekyll-import/importers/drupal6.rb
+++ b/lib/jekyll-import/importers/drupal6.rb
@@ -1,4 +1,4 @@
-require 'jekyll-import/importers/drupal_common.rb'
+require 'jekyll-import/importers/drupal_common'
 
 module JekyllImport
   module Importers
@@ -6,7 +6,7 @@ module JekyllImport
       include DrupalCommon
       extend DrupalCommon::ClassMethods
 
-      def self.get_query(prefix, types)
+      def self.build_query(prefix, types)
         types = types.join("' OR n.type = '")
         types = "n.type = '#{types}'"
 
@@ -31,14 +31,14 @@ EOS
         return query
       end
 
-      def self.get_aliases_query(prefix)
-        return "SELECT src AS source, dst AS alias FROM #{prefix}url_alias WHERE src = ?"
+      def self.aliases_query(prefix)
+        "SELECT src AS source, dst AS alias FROM #{prefix}url_alias WHERE src = ?"
       end
 
-      def self.get_data(post)
-        content = post[:body].to_s
-        summary = post[:teaser].to_s
-        tags = (post[:tags] || '').downcase.strip
+      def self.post_data(sql_post_data)
+        content = sql_post_data[:body].to_s
+        summary = sql_post_data[:teaser].to_s
+        tags = (sql_post_data[:tags] || '').downcase.strip
 
         data = {
           'excerpt' => summary,

--- a/lib/jekyll-import/importers/drupal6.rb
+++ b/lib/jekyll-import/importers/drupal6.rb
@@ -30,7 +30,7 @@ module JekyllImport
       end
 
       def self.get_aliases_query(prefix)
-        return "SELECT dst AS alias FROM #{prefix}url_alias WHERE src = ?"
+        return "SELECT src AS source, dst AS alias FROM #{prefix}url_alias WHERE src = ?"
       end
 
       def self.get_data(post)

--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -39,8 +39,6 @@ module JekyllImport
         summary = post[:body_summary]
         tags = (post[:tags] || '').downcase.strip
 
-        # Get the relevant fields as a hash, delete empty fields and convert
-        # to YAML for the header
         data = {
           :excerpt => summary,
           :categories => tags.split('|')

--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -31,7 +31,7 @@ module JekyllImport
       end
 
       def self.get_aliases_query(prefix)
-        return "SELECT alias FROM #{prefix}url_alias WHERE source = ?"
+        return "SELECT source, alias FROM #{prefix}url_alias WHERE source = ?"
       end
 
       def self.get_data(post)

--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -42,8 +42,8 @@ EOS
         tags = (post[:tags] || '').downcase.strip
 
         data = {
-          :excerpt => summary,
-          :categories => tags.split('|')
+          'excerpt' => summary,
+          'categories' => tags.split('|')
         }
 
         return data, content

--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -10,22 +10,24 @@ module JekyllImport
         types = types.join("' OR n.type = '")
         types = "n.type = '#{types}'"
 
-        query = "SELECT n.nid, \
-                        n.title, \
-                        fdb.body_value, \
-                        fdb.body_summary, \
-                        n.created, \
-                        n.status, \
-                        n.type, \
-                        GROUP_CONCAT( td.name SEPARATOR '|' ) AS 'tags' \
-                  FROM #{prefix}field_data_body AS fdb, \
-                       #{prefix}node AS n \
-                  LEFT OUTER JOIN #{prefix}taxonomy_index AS ti ON ti.nid = n.nid \
-                  LEFT OUTER JOIN #{prefix}taxonomy_term_data AS td ON ti.tid = td.tid \
-                  WHERE (#{types}) \
-                    AND n.nid = fdb.entity_id \
-                    AND n.vid = fdb.revision_id \
-                  GROUP BY n.nid"
+        query = <<EOS
+                SELECT n.nid,
+                       n.title,
+                       fdb.body_value,
+                       fdb.body_summary,
+                       n.created,
+                       n.status,
+                       n.type,
+                       GROUP_CONCAT( td.name SEPARATOR '|' ) AS 'tags'
+                FROM #{prefix}field_data_body AS fdb,
+                     #{prefix}node AS n
+                     LEFT OUTER JOIN #{prefix}taxonomy_index AS ti ON ti.nid = n.nid
+                     LEFT OUTER JOIN #{prefix}taxonomy_term_data AS td ON ti.tid = td.tid
+                WHERE (#{types})
+                  AND n.nid = fdb.entity_id
+                  AND n.vid = fdb.revision_id
+                GROUP BY n.nid"
+EOS
 
         return query
       end

--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -1,4 +1,4 @@
-require 'jekyll-import/importers/drupal_common.rb'
+require 'jekyll-import/importers/drupal_common'
 
 module JekyllImport
   module Importers
@@ -6,7 +6,7 @@ module JekyllImport
       include DrupalCommon
       extend DrupalCommon::ClassMethods
 
-      def self.get_query(prefix, types)
+      def self.build_query(prefix, types)
         types = types.join("' OR n.type = '")
         types = "n.type = '#{types}'"
 
@@ -32,14 +32,14 @@ EOS
         return query
       end
 
-      def self.get_aliases_query(prefix)
-        return "SELECT source, alias FROM #{prefix}url_alias WHERE source = ?"
+      def self.aliases_query(prefix)
+        "SELECT source, alias FROM #{prefix}url_alias WHERE source = ?"
       end
 
-      def self.get_data(post)
-        content = post[:body_value].to_s
-        summary = post[:body_summary].to_s
-        tags = (post[:tags] || '').downcase.strip
+      def self.post_data(sql_post_data)
+        content = sql_post_data[:body_value].to_s
+        summary = sql_post_data[:body_summary].to_s
+        tags = (sql_post_data[:tags] || '').downcase.strip
 
         data = {
           'excerpt' => summary,

--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -35,8 +35,8 @@ module JekyllImport
       end
 
       def self.get_data(post)
-        content = post[:body_value]
-        summary = post[:body_summary]
+        content = post[:body_value].to_s
+        summary = post[:body_summary].to_s
         tags = (post[:tags] || '').downcase.strip
 
         data = {

--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -1,111 +1,54 @@
+require 'jekyll-import/importers/drupal_common.rb'
+
 module JekyllImport
   module Importers
     class Drupal7 < Importer
-      # Reads a MySQL database via Sequel and creates a post file for each story
-      # and blog node.
-      QUERY = "SELECT n.title, \
-                      fdb.body_value, \
-                      fdb.body_summary, \
-                      n.created, \
-                      n.status, \
-                      n.nid, \
-                      u.name \
-               FROM node AS n, \
-                    field_data_body AS fdb, \
-                    users AS u \
-               WHERE (%types%) \
-               AND n.nid = fdb.entity_id \
-               AND n.vid = fdb.revision_id
-               AND n.uid = u.uid"
+      include DrupalCommon
+      extend DrupalCommon::ClassMethods
 
-      def self.validate(options)
-        %w[dbname user].each do |option|
-          if options[option].nil?
-            abort "Missing mandatory option --#{option}."
-          end
-        end
-      end
-
-      def self.specify_options(c)
-        c.option 'dbname', '--dbname DB', 'Database name'
-        c.option 'user', '--user USER', 'Database user name'
-        c.option 'password', '--password PW', 'Database user\'s password (default: "")'
-        c.option 'host', '--host HOST', 'Database host name (default: "localhost")'
-        c.option 'prefix', '--prefix PREFIX', 'Table prefix name'
-        c.option 'types', '--types TYPE1[,TYPE2[,TYPE3...]]', Array, 'The Drupal content types to be imported.'
-      end
-
-      def self.require_deps
-        JekyllImport.require_with_fallback(%w[
-          rubygems
-          sequel
-          fileutils
-          safe_yaml
-        ])
-      end
-
-      def self.process(options)
-        dbname = options.fetch('dbname')
-        user   = options.fetch('user')
-        pass   = options.fetch('password', "")
-        host   = options.fetch('host', "localhost")
-        prefix = options.fetch('prefix', "")
-        types  = options.fetch('types', ['blog', 'story', 'article'])
-
-        db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
-
-        unless prefix.empty?
-          QUERY[" node "] = " " + prefix + "node "
-          QUERY[" field_data_body "] = " " + prefix + "field_data_body "
-          QUERY[" users "] = " " + prefix + "users "
-        end
-
+      def self.get_query(prefix, types)
         types = types.join("' OR n.type = '")
-        QUERY[" WHERE (%types%) "] = " WHERE (n.type = '#{types}') "
+        types = "n.type = '#{types}'"
 
-        FileUtils.mkdir_p "_posts"
-        FileUtils.mkdir_p "_drafts"
-        FileUtils.mkdir_p "_layouts"
+        query = "SELECT n.nid, \
+                        n.title, \
+                        fdb.body_value, \
+                        fdb.body_summary, \
+                        n.created, \
+                        n.status, \
+                        n.type, \
+                        GROUP_CONCAT( td.name SEPARATOR '|' ) AS 'tags' \
+                  FROM #{prefix}field_data_body AS fdb, \
+                       #{prefix}node AS n \
+                  LEFT OUTER JOIN #{prefix}taxonomy_index AS ti ON ti.nid = n.nid \
+                  LEFT OUTER JOIN #{prefix}taxonomy_term_data AS td ON ti.tid = td.tid \
+                  WHERE (#{types}) \
+                    AND n.nid = fdb.entity_id \
+                    AND n.vid = fdb.revision_id \
+                  GROUP BY n.nid"
 
-        db[QUERY].each do |post|
-          # Get required fields and construct Jekyll compatible name
-          title = post[:title]
-          content = post[:body_value]
-          summary = post[:body_summary]
-          created = post[:created]
-          author = post[:name]
-          nid = post[:nid]
-          time = Time.at(created)
-          is_published = post[:status] == 1
-          dir = is_published ? "_posts" : "_drafts"
-          slug = title.strip.downcase.gsub(/(&|&amp;)/, ' and ').gsub(/[\s\.\/\\]/, '-').gsub(/[^\w-]/, '').gsub(/[-_]{2,}/, '-').gsub(/^[-_]/, '').gsub(/[-_]$/, '')
-          name = time.strftime("%Y-%m-%d-") + slug + '.md'
-
-          # Get the relevant fields as a hash, delete empty fields and convert
-          # to YAML for the header
-          data = {
-            'layout' => 'post',
-            'title' => title.strip.force_encoding("UTF-8"),
-            'author' => author,
-            'nid' => nid,
-            'created' => created,
-            'excerpt' => summary
-          }.delete_if { |k,v| v.nil? || v == ''}.to_yaml
-
-          # Write out the data and content to file
-          File.open("#{dir}/#{name}", "w") do |f|
-            f.puts data
-            f.puts "---"
-            f.puts content
-          end
-
-        end
-
-        # TODO: Make dirs & files for nodes of type 'page'
-          # Make refresh pages for these as well
-
-        # TODO: Make refresh dirs & files according to entries in url_alias table
+        return query
       end
+
+      def self.get_aliases_query(prefix)
+        return "SELECT alias FROM #{prefix}url_alias WHERE source = ?"
+      end
+
+      def self.get_data(post)
+        content = post[:body_value]
+        summary = post[:body_summary]
+        tags = (post[:tags] || '').downcase.strip
+
+        # Get the relevant fields as a hash, delete empty fields and convert
+        # to YAML for the header
+        data = {
+          :excerpt => summary,
+          :categories => tags.split('|')
+        }
+
+        return data, content
+      end
+
     end
   end
 end

--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -22,11 +22,11 @@ module JekyllImport
 
         def require_deps
           JekyllImport.require_with_fallback(%w[
-          rubygems
-          sequel
-          fileutils
-          safe_yaml
-        ])
+            rubygems
+            sequel
+            fileutils
+            safe_yaml
+          ])
         end
 
         def process(options)
@@ -39,7 +39,7 @@ module JekyllImport
 
           db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
-          query = self.get_query(prefix, types)
+          query = self.build_query(prefix, types)
 
           src_dir = Jekyll.configuration({})['source']
 
@@ -56,7 +56,7 @@ module JekyllImport
           # Create the refresh layout
           # Change the refresh url if you customized your permalink config
           File.open(File.join(dirs[:_layouts], 'refresh.html'), 'w') do |f|
-            f.puts <<EOF
+            f.puts <<-HTML
 <!DOCTYPE html>
 <html>
 <head>
@@ -64,12 +64,12 @@ module JekyllImport
 <meta http-equiv="refresh" content="0;url={{ page.refresh_to_post_id }}.html" />
 </head>
 </html>
-EOF
+HTML
           end
 
           db[query].each do |post|
             # Get required fields
-            data, content = self.get_data(post)
+            data, content = self.post_data(post)
 
             data['layout'] = post[:type]
             title = data['title'] = post[:title].strip.force_encoding('UTF-8')
@@ -97,7 +97,7 @@ EOF
 
             # Make a file to redirect from the old Drupal URL
             if is_published
-              alias_query = self.get_aliases_query(prefix)
+              alias_query = self.aliases_query(prefix)
               type = post[:type]
 
               aliases = db[alias_query, "#{type}/#{node_id}"].all
@@ -118,11 +118,11 @@ EOF
         end
       end
 
-      def get_query(prefix, types)
+      def build_query(prefix, types)
         raise 'The importer you are trying to use does not implement the get_query() method.'
       end
 
-      def get_aliases_query(prefix)
+      def aliases_query(prefix)
         # Make sure you implement the query returning "alias" as the column name
         # for the URL aliases. See the Drupal 6 importer for an example. The
         # alias field is called 'dst' but we alias it to 'alias', to follow
@@ -130,7 +130,7 @@ EOF
         raise 'The importer you are trying to use does not implement the get_aliases_query() method.'
       end
 
-      def get_data(post)
+      def post_data(sql_post_data)
         raise 'The importer you are trying to use does not implement the get_query() method.'
       end
 

--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -41,13 +41,21 @@ module JekyllImport
 
           query = self.get_query(prefix, types)
 
-          FileUtils.mkdir_p '_posts'
-          FileUtils.mkdir_p '_drafts'
-          FileUtils.mkdir_p '_layouts'
+          src_dir = Jekyll.configuration({})['source']
+
+          dirs = {
+              :_posts => File.join(src_dir, '_posts').to_s,
+              :_drafts => File.join(src_dir, '_drafts').to_s,
+              :_layouts => File.join(src_dir, '_layouts').to_s
+          }
+
+          dirs.each do |key, dir|
+            FileUtils.mkdir_p dir
+          end
 
           # Create the refresh layout
           # Change the refresh url if you customized your permalink config
-          File.open('_layouts/refresh.html', 'w') do |f|
+          File.open(File.join(dirs[:_layouts], 'refresh.html'), 'w') do |f|
             f.puts <<EOF
 <!DOCTYPE html>
 <html>
@@ -75,7 +83,7 @@ EOF
             # Construct a Jekyll compatible file name
             is_published = post[:status] == 1
             node_id = post[:nid]
-            dir = is_published ? '_posts' : '_drafts'
+            dir = is_published ? dirs[:_posts] : dirs[:_drafts]
             slug = title.strip.downcase.gsub(/(&|&amp;)/, ' and ').gsub(/[\s\.\/\\]/, '-').gsub(/[^\w-]/, '').gsub(/[-_]{2,}/, '-').gsub(/^[-_]/, '').gsub(/[-_]$/, '')
             filename = Time.at(time).to_datetime.strftime('%Y-%m-%d-') + slug + '.md'
 

--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -67,6 +67,7 @@ EOF
             title = data[:title] = post[:title].strip.force_encoding('UTF-8')
             time = data[:created] = post[:created]
 
+            # Get the relevant fields as a hash and delete empty fields
             data = data.delete_if { |k,v| v.nil? || v == ''}.each_pair {
                 |k,v| ((v.is_a? String) ? v.force_encoding('UTF-8') : v)
             }

--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -28,6 +28,85 @@ module JekyllImport
           safe_yaml
         ])
         end
+
+        def process(options)
+          dbname = options.fetch('dbname')
+          user   = options.fetch('user')
+          pass   = options.fetch('password', '')
+          host   = options.fetch('host', 'localhost')
+          prefix = options.fetch('prefix', '')
+          types  = options.fetch('types', %w(blog story article))
+
+          db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+
+          query = self.get_query(prefix, types)
+
+          FileUtils.mkdir_p '_posts'
+          FileUtils.mkdir_p '_drafts'
+          FileUtils.mkdir_p '_layouts'
+
+          # Create the refresh layout
+          # Change the refresh url if you customized your permalink config
+          File.open('_layouts/refresh.html', 'w') do |f|
+            f.puts <<EOF
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta http-equiv="refresh" content="0;url={{ page.refresh_to_post_id }}.html" />
+</head>
+</html>
+EOF
+          end
+
+          db[query].each do |post|
+            # Get required fields
+            data, content = self.get_data(post)
+
+            data[:layout] = post[:type]
+            title = data[:title] = post[:title].strip.force_encoding('UTF-8')
+            time = data[:created] = post[:created]
+
+            data = data.delete_if { |k,v| v.nil? || v == ''}.each_pair {
+                |k,v| ((v.is_a? String) ? v.force_encoding('UTF-8') : v)
+            }
+
+            # Construct a Jekyll compatible file name
+            is_published = post[:status] == 1
+            node_id = post[:nid]
+            dir = is_published ? '_posts' : '_drafts'
+            slug = title.strip.downcase.gsub(/(&|&amp;)/, ' and ').gsub(/[\s\.\/\\]/, '-').gsub(/[^\w-]/, '').gsub(/[-_]{2,}/, '-').gsub(/^[-_]/, '').gsub(/[-_]$/, '')
+            filename = Time.at(time).to_datetime.strftime('%Y-%m-%d-') + slug + '.md'
+
+            # Write out the data and content to file
+            File.open("#{dir}/#{filename}", 'w') do |f|
+              f.puts data.to_yaml
+              f.puts '---'
+              f.puts content
+            end
+
+
+            # Make a file to redirect from the old Drupal URL
+            if is_published
+              alias_query = self.get_aliases_query(prefix)
+              type = post[:type]
+
+              aliases = db[alias_query, "#{type}/#{node_id}"].all
+
+              aliases.push(:alias => "#{type}/#{node_id}")
+
+              aliases.each do |url_alias|
+                FileUtils.mkdir_p url_alias[:alias]
+                File.open("#{url_alias[:alias]}/index.md", "w") do |f|
+                  f.puts '---'
+                  f.puts 'layout: refresh'
+                  f.puts "refresh_to_post_id: /#{Time.at(time).to_datetime.strftime('%Y/%m/%d/') + slug}"
+                  f.puts '---'
+                end
+              end
+            end
+          end
+        end
       end
 
       def get_query(prefix, types)
@@ -54,84 +133,7 @@ module JekyllImport
         end
       end
 
-      def process(options)
-        dbname = options.fetch('dbname')
-        user   = options.fetch('user')
-        pass   = options.fetch('password', '')
-        host   = options.fetch('host', 'localhost')
-        prefix = options.fetch('prefix', '')
-        types  = options.fetch('types', %w(blog story article))
 
-        db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
-
-        query = self.get_query(prefix, types)
-
-        FileUtils.mkdir_p '_posts'
-        FileUtils.mkdir_p '_drafts'
-        FileUtils.mkdir_p '_layouts'
-
-        # Create the refresh layout
-        # Change the refresh url if you customized your permalink config
-        File.open('_layouts/refresh.html', 'w') do |f|
-          f.puts <<EOF
-<!DOCTYPE html>
-<html>
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<meta http-equiv="refresh" content="0;url={{ page.refresh_to_post_id }}.html" />
-</head>
-</html>
-EOF
-        end
-
-        db[query].each do |post|
-          # Get required fields
-          data, content = self.get_data(post)
-
-          data[:layout] = post[:type]
-          title = data[:title] = post[:title].strip.force_encoding('UTF-8')
-          time = data[:created] = post[:created]
-
-          data = data.delete_if { |k,v| v.nil? || v == ''}.each_pair {
-              |k,v| ((v.is_a? String) ? v.force_encoding('UTF-8') : v)
-          }
-
-          # Construct a Jekyll compatible file name
-          is_published = post[:status] == 1
-          node_id = post[:nid]
-          dir = is_published ? '_posts' : '_drafts'
-          slug = title.strip.downcase.gsub(/(&|&amp;)/, ' and ').gsub(/[\s\.\/\\]/, '-').gsub(/[^\w-]/, '').gsub(/[-_]{2,}/, '-').gsub(/^[-_]/, '').gsub(/[-_]$/, '')
-          filename = Time.at(time).to_datetime.strftime('%Y-%m-%d-') + slug + '.md'
-
-          # Write out the data and content to file
-          File.open("#{dir}/#{filename}", 'w') do |f|
-            f.puts data.to_yaml
-            f.puts '---'
-            f.puts content
-          end
-
-
-          # Make a file to redirect from the old Drupal URL
-          if is_published
-            alias_query = self.get_aliases_query(prefix)
-            type = post[:type]
-
-            aliases = db[alias_query, "#{type}/#{node_id}"].all
-
-            aliases.push(:alias => "#{type}/#{node_id}")
-
-            aliases.each do |url_alias|
-              FileUtils.mkdir_p url_alias[:alias]
-              File.open("#{url_alias[:alias]}/index.md", "w") do |f|
-                f.puts '---'
-                f.puts 'layout: refresh'
-                f.puts "refresh_to_post_id: /#{Time.at(time).to_datetime.strftime('%Y/%m/%d/') + slug}"
-                f.puts '---'
-              end
-            end
-          end
-        end
-      end
     end
   end
 end

--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -19,6 +19,15 @@ module JekyllImport
           c.option 'prefix', '--prefix PREFIX', 'Table prefix name'
           c.option 'types', '--types TYPE1[,TYPE2[,TYPE3...]]', Array, 'The Drupal content types to be imported.'
         end
+
+        def require_deps
+          JekyllImport.require_with_fallback(%w[
+          rubygems
+          sequel
+          fileutils
+          safe_yaml
+        ])
+        end
       end
 
       def get_query(prefix, types)
@@ -43,15 +52,6 @@ module JekyllImport
             abort "Missing mandatory option --#{option}."
           end
         end
-      end
-
-      def require_deps
-        JekyllImport.require_with_fallback(%w[
-          rubygems
-          sequel
-          fileutils
-          safe_yaml
-        ])
       end
 
       def process(options)

--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -71,9 +71,9 @@ EOF
             # Get required fields
             data, content = self.get_data(post)
 
-            data[:layout] = post[:type]
-            title = data[:title] = post[:title].strip.force_encoding('UTF-8')
-            time = data[:created] = post[:created]
+            data['layout'] = post[:type]
+            title = data['title'] = post[:title].strip.force_encoding('UTF-8')
+            time = data['created'] = post[:created]
 
             # Get the relevant fields as a hash and delete empty fields
             data = data.delete_if { |k,v| v.nil? || v == ''}.each_pair {

--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -1,0 +1,137 @@
+require 'date'
+
+module JekyllImport
+  module Importers
+    module DrupalCommon
+      # This module provides a base for the Drupal importers (at least for 6
+      # and 7; since 8 will be a different beast). Version-specific importers
+      # will need to implement the missing methods from the Importer class.
+      #
+      # The general idea is that this importer reads a MySQL database via Sequel
+      # and creates a post file for each node it finds in the Drupal database.
+
+      module ClassMethods
+        def specify_options(c)
+          c.option 'dbname', '--dbname DB', 'Database name'
+          c.option 'user', '--user USER', 'Database user name'
+          c.option 'password', '--password PW', "Database user's password (default: '')"
+          c.option 'host', '--host HOST', 'Database host name (default: "localhost")'
+          c.option 'prefix', '--prefix PREFIX', 'Table prefix name'
+          c.option 'types', '--types TYPE1[,TYPE2[,TYPE3...]]', Array, 'The Drupal content types to be imported.'
+        end
+      end
+
+      def get_query(prefix, types)
+        raise 'The importer you are trying to use does not implement the get_query() method.'
+      end
+
+      def get_aliases_query(prefix)
+        # Make sure you implement the query returning "alias" as the column name
+        # for the URL aliases. See the Drupal 6 importer for an example. The
+        # alias field is called 'dst' but we alias it to 'alias', to follow
+        # Drupal 7's column names.
+        raise 'The importer you are trying to use does not implement the get_aliases_query() method.'
+      end
+
+      def get_data(post)
+        raise 'The importer you are trying to use does not implement the get_query() method.'
+      end
+
+      def validate(options)
+        %w[dbname user].each do |option|
+          if options[option].nil?
+            abort "Missing mandatory option --#{option}."
+          end
+        end
+      end
+
+      def require_deps
+        JekyllImport.require_with_fallback(%w[
+          rubygems
+          sequel
+          fileutils
+          safe_yaml
+        ])
+      end
+
+      def process(options)
+        dbname = options.fetch('dbname')
+        user   = options.fetch('user')
+        pass   = options.fetch('password', '')
+        host   = options.fetch('host', 'localhost')
+        prefix = options.fetch('prefix', '')
+        types  = options.fetch('types', %w(blog story article))
+
+        db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+
+        query = self.get_query(prefix, types)
+
+        FileUtils.mkdir_p '_posts'
+        FileUtils.mkdir_p '_drafts'
+        FileUtils.mkdir_p '_layouts'
+
+        # Create the refresh layout
+        # Change the refresh url if you customized your permalink config
+        File.open('_layouts/refresh.html', 'w') do |f|
+          f.puts <<EOF
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta http-equiv="refresh" content="0;url={{ page.refresh_to_post_id }}.html" />
+</head>
+</html>
+EOF
+        end
+
+        db[query].each do |post|
+          # Get required fields
+          data, content = self.get_data(post)
+
+          data[:layout] = post[:type]
+          title = data[:title] = post[:title].strip.force_encoding('UTF-8')
+          time = data[:created] = post[:created]
+
+          data = data.delete_if { |k,v| v.nil? || v == ''}.each_pair {
+              |k,v| ((v.is_a? String) ? v.force_encoding('UTF-8') : v)
+          }
+
+          # Construct a Jekyll compatible file name
+          is_published = post[:status] == 1
+          node_id = post[:nid]
+          dir = is_published ? '_posts' : '_drafts'
+          slug = title.strip.downcase.gsub(/(&|&amp;)/, ' and ').gsub(/[\s\.\/\\]/, '-').gsub(/[^\w-]/, '').gsub(/[-_]{2,}/, '-').gsub(/^[-_]/, '').gsub(/[-_]$/, '')
+          filename = Time.at(time).to_datetime.strftime('%Y-%m-%d-') + slug + '.md'
+
+          # Write out the data and content to file
+          File.open("#{dir}/#{filename}", 'w') do |f|
+            f.puts data.to_yaml
+            f.puts '---'
+            f.puts content
+          end
+
+
+          # Make a file to redirect from the old Drupal URL
+          if is_published
+            alias_query = self.get_aliases_query(prefix)
+            type = post[:type]
+
+            aliases = db[alias_query, "#{type}/#{node_id}"].all
+
+            aliases.push(:alias => "#{type}/#{node_id}")
+
+            aliases.each do |url_alias|
+              FileUtils.mkdir_p url_alias[:alias]
+              File.open("#{url_alias[:alias]}/index.md", "w") do |f|
+                f.puts '---'
+                f.puts 'layout: refresh'
+                f.puts "refresh_to_post_id: /#{Time.at(time).to_datetime.strftime('%Y/%m/%d/') + slug}"
+                f.puts '---'
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Big refactoring of the Drupal importers.

All the code that was repeated on both Drupal6 and Drupal7 importers was pulled up into a generic `DrupalAbstract` class which implements the "core" logic of the Drupal importers and delegates the version-specific code to sub-classes.

I would appreciate it if someone could test importing non-Drupal content, though, because I don't have another blog to test the non-Drupal importers with.