### PR TITLE
Drupal 6 importer depends on mysql.

### DIFF
--- a/lib/jekyll-import/importers/drupal6.rb
+++ b/lib/jekyll-import/importers/drupal6.rb
@@ -40,6 +40,7 @@ module JekyllImport
           sequel
           fileutils
           safe_yaml
+          mysql
         ])
       end
 


### PR DESCRIPTION
When I try to import data from Drupal 6 I get the following error because the `mysql` gem is missing:

```
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': LoadError: cannot load such file -- mysql (Sequel::AdapterNotFound)
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/pieter/.gem/ruby/2.3.0/gems/sequel-4.32.0/lib/sequel/adapters/mysql.rb:6:in `rescue in <top (required)>'
	from /home/pieter/.gem/ruby/2.3.0/gems/sequel-4.32.0/lib/sequel/adapters/mysql.rb:3:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/pieter/.gem/ruby/2.3.0/gems/sequel-4.32.0/lib/sequel/database/connecting.rb:98:in `load_adapter'
	from /home/pieter/.gem/ruby/2.3.0/gems/sequel-4.32.0/lib/sequel/database/connecting.rb:28:in `adapter_class'
	from /home/pieter/.gem/ruby/2.3.0/gems/sequel-4.32.0/lib/sequel/database/connecting.rb:56:in `connect'
	from /home/pieter/.gem/ruby/2.3.0/gems/sequel-4.32.0/lib/sequel/core.rb:108:in `connect'
	from /home/pieter/.gem/ruby/2.3.0/gems/sequel-4.32.0/lib/sequel/core.rb:377:in `adapter_method'
	from /home/pieter/.gem/ruby/2.3.0/gems/sequel-4.32.0/lib/sequel/core.rb:387:in `mysql'
	from /home/pieter/.gem/ruby/2.3.0/gems/jekyll-import-0.10.0/lib/jekyll-import/importers/drupal6.rb:54:in `process'
	from /home/pieter/.gem/ruby/2.3.0/gems/jekyll-import-0.10.0/lib/jekyll-import/importer.rb:23:in `run'
	from -e:2:in `<main>'
```