### PR TITLE
Correct "our help repo" link

### DIFF
--- a/site/_docs/contributing.md
+++ b/site/_docs/contributing.md
@@ -18,7 +18,7 @@ Found an issue with one of the importers? Sorry about that! In order to better a
 4. Ensure the `--trace` option is specified if you're running `jekyll import` from the command-line.
 4. [Open a new issue]({{ site.repository }}/issues/new) describing the four above points, as well as what you expected the outcome of your incantation to be.
 
-You should receive help soon. As always, check out [our help repo](https;//github.com/jekyll/jekyll-help) if you just have a question.
+You should receive help soon. As always, check out [our help repo](https://github.com/jekyll/jekyll-help) if you just have a question.
 
 ## Creating a New Importer
 


### PR DESCRIPTION
Hello, :smiley:

I **correct "our help repo" link**. :pencil:

The links redirects to *`http://import.jekyllrb.com/docs/contributing/https;//github.com/jekyll/jekyll-help`*. But it must go to *`https://github.com/jekyll/jekyll-help`*!

> You guys are using ***semicolon*** instead of a ***colon*** *in the HTTP protocol* ! XD


*Yours,*
[**Suriyaa Kudo**](https://github.com/SuriyaaKudoIsc) :octocat: