### PR TITLE
Tumblr: fix stripping of JSONP characters from feed

### DIFF
--- a/lib/jekyll-import/importers/tumblr.rb
+++ b/lib/jekyll-import/importers/tumblr.rb
@@ -44,7 +44,7 @@ module JekyllImport
           contents = feed.readlines.join("\n")
           beginning = contents.index("{")
           ending = contents.rindex("}")
-          json = feed.readlines.join("\n")[beginning...ending]  # Strip Tumblr's JSONP chars.
+          json = contents[beginning..ending]  # Strip Tumblr's JSONP chars.
           blog = JSON.parse(json)
           puts "Page: #{current_page + 1} - Posts: #{blog["posts"].size}"
           batch = blog["posts"].map { |post| post_to_hash(post, format) }


### PR DESCRIPTION
should not try to read all lines twice from same stream (`feed`).
looked up docs for ruby arrays and ranges.