### PR TITLE
Tumblr: Fixing double-read and off-by-one error

### DIFF
--- a/lib/jekyll-import/importers/tumblr.rb
+++ b/lib/jekyll-import/importers/tumblr.rb
@@ -43,8 +43,8 @@ module JekyllImport
           feed = open(feed_url)
           contents = feed.readlines.join("\n")
           beginning = contents.index("{")
-          ending = contents.rindex("}")
-          json = contents[beginning..ending]  # Strip Tumblr's JSONP chars.
+          ending = contents.rindex("}")+1
+          json = contents[beginning...ending]  # Strip Tumblr's JSONP chars.
           blog = JSON.parse(json)
           puts "Page: #{current_page + 1} - Posts: #{blog["posts"].size}"
           batch = blog["posts"].map { |post| post_to_hash(post, format) }


### PR DESCRIPTION
Found these bugs after I ran into #252 

Fixing two bugs introduced recently:
- `feed` was getting read from twice, so the second time it was empty
- `ending` marks the index of the right-most `}`, but needed to be
  bumped by 1 when referenced in the array

Signed-off-by: Dave Henderson <dhenderson@gmail.com>