### PR TITLE
joomla: use & require mysql2 instead of mysql

### DIFF
--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -22,6 +22,7 @@ module JekyllImport
         JekyllImport.require_with_fallback(%w[
           rubygems
           sequel
+          mysql2
           fileutils
           safe_yaml
         ])
@@ -35,7 +36,7 @@ module JekyllImport
         section = options.fetch('section', '1')
         table_prefix = options.fetch('prefix', "jos_")
 
-        db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+        db = Sequel.mysql2(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
         FileUtils.mkdir_p("_posts")
 


### PR DESCRIPTION
joomla.rb was using Sequel.mysql, which appears to depend on the gem mysql.  This is depracated and replacing mysql with mysql2 works fine;  it is already in use for wordpress.rb.  I also added the requirement for the mysql2 gem, as this doesn't appear to work without that.

Details of my error message when running the vanilla joomla importer without mysql:

```
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require': LoadError: cannot load such file -- mysql (Sequel::AdapterNotFound)
        from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Library/Ruby/Gems/2.0.0/gems/sequel-4.34.0/lib/sequel/adapters/mysql.rb:6:in `rescue in <top (required)>'
        from /Library/Ruby/Gems/2.0.0/gems/sequel-4.34.0/lib/sequel/adapters/mysql.rb:3:in `<top (required)>'
        from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Library/Ruby/Gems/2.0.0/gems/sequel-4.34.0/lib/sequel/database/connecting.rb:98:in `load_adapter'
        from /Library/Ruby/Gems/2.0.0/gems/sequel-4.34.0/lib/sequel/database/connecting.rb:28:in `adapter_class'
        from /Library/Ruby/Gems/2.0.0/gems/sequel-4.34.0/lib/sequel/database/connecting.rb:56:in `connect'
        from /Library/Ruby/Gems/2.0.0/gems/sequel-4.34.0/lib/sequel/core.rb:108:in `connect'
        from /Library/Ruby/Gems/2.0.0/gems/sequel-4.34.0/lib/sequel/core.rb:377:in `adapter_method'
        from /Library/Ruby/Gems/2.0.0/gems/sequel-4.34.0/lib/sequel/core.rb:387:in `mysql'
        from /Library/Ruby/Gems/2.0.0/gems/jekyll-import-0.10.0/lib/jekyll-import/importers/joomla.rb:38:in `process'
        from /Library/Ruby/Gems/2.0.0/gems/jekyll-import-0.10.0/lib/jekyll-import/importer.rb:23:in `run'
        from -e:2:in `<main>
```
`

I suggest, furthermore, that we say MySQL (not the gem) needs to be installed, which is not obvious to people who rent their webserver and database from a third party (i.e., me! heh).  I'm not sure how to edit the documentation for joomla.rb, but it definitely needs to go onto individual importer pages, since a user of X CMS will not be looking over the documentation for Y CMS necessarily.

This is my first ever pull request so any comments on how I've done it are welcome.