### PR TITLE
Add functionality for importing Blogger comments

### DIFF
--- a/lib/jekyll-import/importers/blogger.rb
+++ b/lib/jekyll-import/importers/blogger.rb
@@ -143,6 +143,10 @@ module JekyllImport
             if @in_entry_elem
               @in_entry_elem[:meta][:thumbnail] = attrs['url']
             end
+          when 'thr:in-reply-to'
+            if @in_entry_elem
+              @in_entry_elem[:meta][:post_id] = attrs['ref']
+            end
           end
         end
 
@@ -182,6 +186,23 @@ module JekyllImport
               if post_data
                 target_dir = '_posts'
                 target_dir = '_drafts' if @in_entry_elem[:meta][:draft]
+
+                FileUtils.mkdir_p(target_dir)
+
+                file_name = URI::decode("#{post_data[:filename]}.html")
+                File.open(File.join(target_dir, file_name), 'w') do |f|
+                  f.flock(File::LOCK_EX)
+
+                  f << post_data[:header].to_yaml
+                  f << "---\n\n"
+                  f << post_data[:body]
+                end
+              end
+            elsif @in_entry_elem[:meta][:kind] == 'comment'
+              post_data = get_post_data_from_in_entry_elem_info
+
+              if post_data
+                target_dir = '_comments'
 
                 FileUtils.mkdir_p(target_dir)
 
@@ -235,6 +256,48 @@ module JekyllImport
               'date' => @in_entry_elem[:meta][:published],
               'author' => @in_entry_elem[:meta][:author],
               'tags' => @in_entry_elem[:meta][:category],
+            }
+            header['modified_time'] = @in_entry_elem[:meta][:updated] if @in_entry_elem[:meta][:updated] && @in_entry_elem[:meta][:updated] != @in_entry_elem[:meta][:published]
+            header['thumbnail'] = @in_entry_elem[:meta][:thumbnail] if @in_entry_elem[:meta][:thumbnail]
+            header['blogger_id'] = @in_entry_elem[:meta][:id] if @leave_blogger_info
+            header['blogger_orig_url'] = @in_entry_elem[:meta][:original_url] if @leave_blogger_info && @in_entry_elem[:meta][:original_url]
+
+            body = @in_entry_elem[:body]
+
+            # body escaping associated with liquid
+            if body =~ /{{/
+              body.gsub!(/{{/, '{{ "{{" }}')
+            end
+            if body =~ /{%/
+              body.gsub!(/{%/, '{{ "{%" }}')
+            end
+
+            { :filename => filename, :header => header, :body => body }
+          elsif @in_entry_elem[:meta][:kind] == 'comment'
+            timestamp = Time.parse(@in_entry_elem[:meta][:published]).strftime('%Y-%m-%d')
+            if @in_entry_elem[:meta][:original_url]
+              if not @comment_seq
+                @comment_seq = 1
+              end
+
+              original_uri = URI.parse(@in_entry_elem[:meta][:original_url])
+              original_path = original_uri.path.to_s
+              filename = "%s-%s-%s" %
+                [timestamp,
+                 File.basename(original_path, File.extname(original_path)),
+                 @comment_seq]
+
+              @comment_seq = @comment_seq + 1
+
+              @original_url_base = "#{original_uri.scheme}://#{original_uri.host}"
+            else
+              raise 'Original URL is missing'
+            end
+
+            header = {
+              'date' => @in_entry_elem[:meta][:published],
+              'author' => @in_entry_elem[:meta][:author],
+              'blogger_post_id' => @in_entry_elem[:meta][:post_id],
             }
             header['modified_time'] = @in_entry_elem[:meta][:updated] if @in_entry_elem[:meta][:updated] && @in_entry_elem[:meta][:updated] != @in_entry_elem[:meta][:published]
             header['thumbnail'] = @in_entry_elem[:meta][:thumbnail] if @in_entry_elem[:meta][:thumbnail]


### PR DESCRIPTION
Similar to the [WordPress importer](https://import.jekyllrb.com/docs/wordpress/), this PR adds support for importing comments from Blogger.

When `comments: true` is specified in `options` comments are written to a custom collection `_comments`. They are named according to the slug of the post, such as `2016-01-my-post-<number>.html` where `<number>` is a simple incrementing counter. To be able to connect comments with posts, there is a metadata field on the front matter `blogger_post_id` which refers to the post the comment is for (matches the `blogger_id` on posts).

Usage example can be seen on the blog I just imported, http://joscarsson.github.io/runtjordennu (warning, Swedish). The comments are added to the posts [through a generator](https://github.com/joscarsson/runtjordennu/blob/master/_plugins/static_comments.rb), and used [when rendering the posts](https://github.com/joscarsson/runtjordennu/blob/master/_layouts/post.html#L16-L27).

I don't usually code in Ruby, so this might be very non-standard/wrong - feel free to comment/give corrections.