### PR TITLE
Add S9y database importer

### DIFF
--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -54,6 +54,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('behance', "~> 0.3")
   s.add_development_dependency('unidecode')
   s.add_development_dependency('open_uri_redirections')
+  s.add_development_dependency('reverse_markdown')
 
   # site dependencies:
   s.add_development_dependency('launchy', '~> 2.4')

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -146,7 +146,7 @@ module JekyllImport
 
         status = post[:isdraft] == 'true' ? 'draft' : 'published'
         date = Time.at(post[:timestamp]) || Time.now
-        name = "%02d-%02d-%02d-%02d-%02d-%s.%s" % [date.year, date.month, date.day, date.hour, date.min, slug, extension]
+        name = "%02d-%02d-%02d_%02d-%02d-%s.%s" % [date.year, date.month, date.day, date.hour, date.min, slug, extension]
 
         content = post[:body].to_s
 

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -126,7 +126,7 @@ module JekyllImport
              LEFT JOIN #{px}authors AS `authors`
                ON entries.authorid = authors.authorid"
 
-        if !options[:drafts]
+        unless options[:drafts]
           posts_query << "WHERE posts.isdraft = 'false'"
         end
 
@@ -144,7 +144,7 @@ module JekyllImport
         end
 
         slug = post[:slug]
-        if !slug or slug.empty?
+        if !slug || slug.empty?
           slug = sluggify(title)
         end
 

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -76,23 +76,11 @@ module JekyllImport
         }
 
         if options[:clean_entities]
-          begin
-            require 'htmlentities'
-          rescue LoadError
-            STDERR.puts "Could not require 'htmlentities', so the " +
-              ":clean_entities option is now disabled."
-            options[:clean_entities] = false
-          end
+          options[:clean_entities] = require_if_available('htmlentities', 'clean_entities')
         end
 
         if options[:markdown]
-          begin
-            require 'reverse_markdown'
-          rescue LoadError
-            STDERR.puts "Could not require 'reverse_markdown', so the " +
-              ":markdown option is now disabled."
-            options[:markdown] = false
-          end
+          options[:markdown] = require_if_available('reverse_markdown', 'markdown')
         end
 
         FileUtils.mkdir_p("_posts")
@@ -208,6 +196,16 @@ module JekyllImport
           f.puts data
           f.puts "---"
           f.puts Util.wpautop(content)
+        end
+      end
+
+      def self.require_if_available(gem_name, option_name)
+        begin
+          require gem_name
+          return true
+        rescue LoadError
+          STDERR.puts "Could not require '#{gem_name}', so the :#{option_name} option is now disabled."
+          return true
         end
       end
 

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -149,8 +149,8 @@ module JekyllImport
         end
 
         status = post[:isdraft] == 'true' ? 'draft' : 'published'
-        date = Time.at(post[:timestamp]) || Time.now
-        name = "%02d-%02d-%02d_%02d-%02d-%s.%s" % [date.year, date.month, date.day, date.hour, date.min, slug, extension]
+        date = Time.at(post[:timestamp]).utc || Time.now.utc
+        name = "%02d-%02d-%02d-%s.%s" % [date.year, date.month, date.day, slug, extension]
 
         content = post[:body].to_s
 

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -1,6 +1,6 @@
 module JekyllImport
   module Importers
-    class S9YMySQL < Importer
+    class S9YDatabase < Importer
 
       def self.require_deps
         JekyllImport.require_with_fallback(

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -24,7 +24,7 @@ module JekyllImport
         c.option 'comments', '--comments', 'Whether to import comments (default: true)'
         c.option 'categories', '--categories', 'Whether to import categories (default: true)'
         c.option 'tags', '--tags', 'Whether to import tags (default: true)'
-        c.option 'export_drafts', '--export_drafts', 'Whether to export drafts as well'
+        c.option 'drafts', '--drafts', 'Whether to export drafts as well'
         c.option 'markdown', '--markdown', 'convert into markdown format (default: false)'
         c.option 'permalinks', '--permalinks', 'preserve S9Y permalinks (default: false)'
       end
@@ -54,7 +54,7 @@ module JekyllImport
       # :tags::           If true, save the post's tags in its
       #                   YAML front matter. Default: true.
       # :extension::      Set the post extension. Default: "html"
-      # :export_drafts::  If true, export drafts as well
+      # :drafts::  If true, export drafts as well
       #                   Default: true.
       # :markdown::       If true, convert the content to markdown
       #                   Default: false
@@ -74,7 +74,7 @@ module JekyllImport
           :categories     => opts.fetch('categories', true),
           :tags           => opts.fetch('tags', true),
           :extension      => opts.fetch('extension', 'html'),
-          :export_drafts  => opts.fetch('export_drafts', true),
+          :drafts  => opts.fetch('drafts', true),
           :markdown       => opts.fetch('markdown', false),
           :permalinks     => opts.fetch('permalinks', false),
         }
@@ -88,7 +88,7 @@ module JekyllImport
         end
 
         FileUtils.mkdir_p("_posts")
-        FileUtils.mkdir_p("_drafts") if options[:export_drafts]
+        FileUtils.mkdir_p("_drafts") if options[:drafts]
 
         db = Sequel.mysql2(options[:dbname], :user => options[:user], :password => options[:pass],
                            :socket => options[:socket], :host => options[:host], :encoding => 'utf8')
@@ -126,7 +126,7 @@ module JekyllImport
              LEFT JOIN #{px}authors AS `authors`
                ON entries.authorid = authors.authorid"
 
-        if !options[:export_drafts]
+        if !options[:drafts]
           posts_query << "WHERE posts.isdraft = 'false'"
         end
 

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -74,7 +74,7 @@ module JekyllImport
           :categories     => opts.fetch('categories', true),
           :tags           => opts.fetch('tags', true),
           :extension      => opts.fetch('extension', 'html'),
-          :drafts  => opts.fetch('drafts', true),
+          :drafts         => opts.fetch('drafts', true),
           :markdown       => opts.fetch('markdown', false),
           :permalinks     => opts.fetch('permalinks', false),
         }

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -10,7 +10,6 @@ module JekyllImport
           fileutils
           safe_yaml
           unidecode
-          reverse_markdown
           ])
       end
 
@@ -83,6 +82,16 @@ module JekyllImport
             STDERR.puts "Could not require 'htmlentities', so the " +
               ":clean_entities option is now disabled."
             options[:clean_entities] = false
+          end
+        end
+
+        if options[:markdown]
+          begin
+            require 'reverse_markdown'
+          rescue LoadError
+            STDERR.puts "Could not require 'reverse_markdown', so the " +
+              ":markdown option is now disabled."
+            options[:markdown] = false
           end
         end
 

--- a/lib/jekyll-import/importers/s9y_mysql.rb
+++ b/lib/jekyll-import/importers/s9y_mysql.rb
@@ -143,7 +143,7 @@ module JekyllImport
           slug = sluggify(title)
         end
 
-        status = post[:isdraft] ? 'draft' : 'published'
+        status = post[:isdraft] == 'true' ? 'draft' : 'published'
         date = Time.at(post[:timestamp]) || Time.now
         name = "%02d-%02d-%02d-%02d-%02d-%s.%s" % [date.year, date.month, date.day, date.hour, date.min, slug, extension]
 
@@ -229,7 +229,7 @@ module JekyllImport
         data = {
           'layout'        => post[:type].to_s,
           'status'        => status.to_s,
-          'published'     => status.to_s == 'draft' ? nil : (post[:status].to_s == 'published'),
+          'published'     => status.to_s == 'draft' ? nil : (status.to_s == 'published'),
           'title'         => title.to_s,
           'author'        => {
             'display_name'=> post[:author].to_s,
@@ -246,7 +246,7 @@ module JekyllImport
         if post[:type] == 'page'
           filename = page_path(post[:id], page_name_list) + "index.#{extension}"
           FileUtils.mkdir_p(File.dirname(filename))
-        elsif post[:status] == 'draft'
+        elsif status == 'draft'
           filename = "_drafts/#{slug}.#{extension}"
         else
           filename = "_posts/#{name}"

--- a/lib/jekyll-import/importers/s9y_mysql.rb
+++ b/lib/jekyll-import/importers/s9y_mysql.rb
@@ -1,0 +1,297 @@
+module JekyllImport
+  module Importers
+    class S9YMySQL < Importer
+
+      def self.require_deps
+        JekyllImport.require_with_fallback(
+          %w[
+          rubygems
+          sequel
+          fileutils
+          safe_yaml
+          unidecode
+          reverse_markdown
+          ])
+      end
+
+      def self.specify_options(c)
+        c.option 'dbname', '--dbname DB', 'Database name (default: "")'
+        c.option 'socket', '--socket SOCKET', 'Database socket (default: "")'
+        c.option 'user', '--user USER', 'Database user name (default: "")'
+        c.option 'password', '--password PW', "Database user's password (default: "")"
+        c.option 'host', '--host HOST', 'Database host name (default: "localhost")'
+        c.option 'table_prefix', '--table_prefix PREFIX', 'Table prefix name (default: "serendipity_")'
+        c.option 'clean_entities', '--clean_entities', 'Whether to clean entities (default: true)'
+        c.option 'comments', '--comments', 'Whether to import comments (default: true)'
+        c.option 'categories', '--categories', 'Whether to import categories (default: true)'
+        c.option 'export_drafts', '--export_drafts', 'Whether to export drafts as well'
+        c.option 'markdown', '--markdown', 'convert into markdown format (default: false)'
+      end
+
+      # Main migrator function. Call this to perform the migration.
+      #
+      # dbname::  The name of the database
+      # user::    The database user name
+      # pass::    The database user's password
+      # host::    The address of the MySQL database host. Default: 'localhost'
+      # socket::  The database socket's path
+      # options:: A hash table of configuration options.
+      #
+      # Supported options are:
+      #
+      # :table_prefix::   Prefix of database tables used by WordPress.
+      #                   Default: 'serendipity_'
+      # :clean_entities:: If true, convert non-ASCII characters to HTML
+      #                   entities in the posts, comments, titles, and
+      #                   names. Requires the 'htmlentities' gem to
+      #                   work. Default: true.
+      # :comments::       If true, migrate post comments too. Comments
+      #                   are saved in the post's YAML front matter.
+      #                   Default: true.
+      # :categories::     If true, save the post's categories in its
+      #                   YAML front matter. Default: true.
+      # :extension::      Set the post extension. Default: "html"
+      # :export_drafts::  If true, export drafts as well
+      #                   Default: true.
+      # :markdown::       If true, convert the content to markdown
+      #                   Default: false
+      #
+      def self.process(opts)
+        options = {
+          :user           => opts.fetch('user', ''),
+          :pass           => opts.fetch('password', ''),
+          :host           => opts.fetch('host', 'localhost'),
+          :socket         => opts.fetch('socket', nil),
+          :dbname         => opts.fetch('dbname', ''),
+          :table_prefix   => opts.fetch('table_prefix', 'serendipity_'),
+          :clean_entities => opts.fetch('clean_entities', true),
+          :comments       => opts.fetch('comments', true),
+          :categories     => opts.fetch('categories', true),
+          :extension      => opts.fetch('extension', 'html'),
+          :export_drafts  => opts.fetch('export_drafts', true),
+          :markdown       => opts.fetch('markdown', false)
+        }
+
+        if options[:clean_entities]
+          begin
+            require 'htmlentities'
+          rescue LoadError
+            STDERR.puts "Could not require 'htmlentities', so the " +
+              ":clean_entities option is now disabled."
+            options[:clean_entities] = false
+          end
+        end
+
+        FileUtils.mkdir_p("_posts")
+        FileUtils.mkdir_p("_drafts") if options[:export_drafts]
+
+        db = Sequel.mysql2(options[:dbname], :user => options[:user], :password => options[:pass],
+                           :socket => options[:socket], :host => options[:host], :encoding => 'utf8')
+
+        px = options[:table_prefix]
+
+        page_name_list = {}
+
+        page_name_query = "
+           SELECT
+             entries.ID             AS `id`,
+             entries.title          AS `title`
+           FROM #{px}entries AS `entries`"
+
+        db[page_name_query].each do |page|
+          page[:slug] = sluggify(page[:title])
+
+          page_name_list[ page[:id] ] = {
+            :slug   => page[:slug]
+          }
+        end
+
+        posts_query = "
+           SELECT
+             entries.ID             AS `id`,
+             entries.isdraft        AS `isdraft`,
+             entries.title          AS `title`,
+             entries.timestamp      AS `timestamp`,
+             entries.body           AS `body`,
+             authors.realname     AS `author`,
+             authors.username     AS `author_login`,
+             authors.email        AS `author_email`
+           FROM #{px}entries AS `entries`
+             LEFT JOIN #{px}authors AS `authors`
+               ON entries.authorid = authors.authorid"
+
+        if !options[:export_drafts]
+          posts_query << "WHERE posts.isdraft = 'false'"
+        end
+
+        db[posts_query].each do |post|
+          process_post(post, db, options, page_name_list)
+        end
+      end
+
+      def self.process_post(post, db, options, page_name_list)
+        px = options[:table_prefix]
+        extension = options[:extension]
+
+        title = post[:title]
+        if options[:clean_entities]
+          title = clean_entities(title)
+        end
+
+        slug = post[:slug]
+        if !slug or slug.empty?
+          slug = sluggify(title)
+        end
+
+        status = post[:isdraft] ? 'draft' : 'published'
+        date = Time.at(post[:timestamp]) || Time.now
+        name = "%02d-%02d-%02d-%02d-%02d-%s.%s" % [date.year, date.month, date.day, date.hour, date.min, slug, extension]
+
+        content = post[:body].to_s
+
+        if options[:clean_entities]
+          content = clean_entities(content)
+        end
+
+        if options[:markdown]
+         content = ReverseMarkdown.convert(content)
+        end
+
+        categories = []
+
+        if options[:categories]
+          cquery =
+            "SELECT
+               categories.category_name AS `name`
+             FROM
+            #{px}entrycat AS `entrycat`,
+            #{px}category AS `categories`
+             WHERE
+               entrycat.entryid = '#{post[:id]}' AND
+               entrycat.categoryid = categories.categoryid"
+
+            db[cquery].each do |category|
+            if options[:categories]
+              if options[:clean_entities]
+                categories << clean_entities(category[:name])
+              else
+                categories << category[:name]
+              end
+            end
+            end
+        end
+
+        comments = []
+
+        if options[:comments]
+          cquery =
+            "SELECT
+               id           AS `id`,
+               author       AS `author`,
+               email        AS `author_email`,
+               url          AS `author_url`,
+               timestamp    AS `date`,
+               body         AS `content`
+             FROM #{px}comments
+             WHERE
+               entry_id = '#{post[:id]}' AND
+               status = 'approved'"
+
+            db[cquery].each do |comment|
+              comcontent = comment[:content].to_s
+              if comcontent.respond_to?(:force_encoding)
+                comcontent.force_encoding("UTF-8")
+              end
+              if options[:clean_entities]
+                comcontent = clean_entities(comcontent)
+              end
+
+              comauthor = comment[:author].to_s
+              if options[:clean_entities]
+                comauthor = clean_entities(comauthor)
+              end
+
+              comments << {
+                'id'           => comment[:id].to_i,
+                'author'       => comauthor,
+                'author_email' => comment[:author_email].to_s,
+                'author_url'   => comment[:author_url].to_s,
+                'date'         => comment[:date].to_s,
+                'content'      => comcontent,
+              }
+            end
+
+          comments.sort!{ |a,b| a['id'] <=> b['id'] }
+        end
+
+        # Get the relevant fields as a hash, delete empty fields and
+        # convert to YAML for the header.
+        data = {
+          'layout'        => post[:type].to_s,
+          'status'        => status.to_s,
+          'published'     => status.to_s == 'draft' ? nil : (post[:status].to_s == 'published'),
+          'title'         => title.to_s,
+          'author'        => {
+            'display_name'=> post[:author].to_s,
+            'login'       => post[:author_login].to_s,
+            'email'       => post[:author_email].to_s
+          },
+          'author_login'  => post[:author_login].to_s,
+          'author_email'  => post[:author_email].to_s,
+          'date'          => date.to_s,
+          'categories'    => options[:categories] ? categories : nil,
+          'comments'      => options[:comments] ? comments : nil,
+        }.delete_if { |k,v| v.nil? || v == '' }.to_yaml
+
+        if post[:type] == 'page'
+          filename = page_path(post[:id], page_name_list) + "index.#{extension}"
+          FileUtils.mkdir_p(File.dirname(filename))
+        elsif post[:status] == 'draft'
+          filename = "_drafts/#{slug}.#{extension}"
+        else
+          filename = "_posts/#{name}"
+        end
+
+        # Write out the data and content to file
+        File.open(filename, "w") do |f|
+          f.puts data
+          f.puts "---"
+          f.puts Util.wpautop(content)
+        end
+      end
+
+      def self.clean_entities( text )
+        if text.respond_to?(:force_encoding)
+          text.force_encoding("UTF-8")
+        end
+        text = HTMLEntities.new.encode(text, :named)
+        # We don't want to convert these, it would break all
+        # HTML tags in the post and comments.
+        text.gsub!("&amp;", "&")
+        text.gsub!("&lt;", "<")
+        text.gsub!("&gt;", ">")
+        text.gsub!("&quot;", '"')
+        text.gsub!("&apos;", "'")
+        text.gsub!("/", "&#47;")
+        text
+      end
+
+      def self.sluggify( title )
+        title.to_ascii.downcase.gsub(/[^0-9A-Za-z]+/, " ").strip.gsub(" ", "-")
+      end
+
+      def self.page_path( page_id, page_name_list )
+        if page_name_list.key?(page_id)
+          [
+            page_name_list[page_id][:slug],
+            '/'
+          ].join("")
+        else
+          ""
+        end
+      end
+
+    end
+  end
+end
+

--- a/site/_importers/s9y.md
+++ b/site/_importers/s9y.md
@@ -3,7 +3,7 @@ layout: docs
 title: S9Y
 prev_section: rss
 link_source:  s9y
-next_section: textpattern
+next_section: s9ydatabase
 permalink: /docs/s9y/
 ---
 

--- a/site/_importers/s9ydatabase.md
+++ b/site/_importers/s9ydatabase.md
@@ -32,7 +32,8 @@ $ ruby -rubygems -e 'require "jekyll-import";
       "tags"           => true,
       "extension"      => "html",
       "export_drafts " => true,
-      "markdown"       => false
+      "markdown"       => false,
+      "permalinks"     => false
     })
 {% endhighlight %}
 

--- a/site/_importers/s9ydatabase.md
+++ b/site/_importers/s9ydatabase.md
@@ -11,7 +11,7 @@ permalink: /docs/s9ydatabase/
   <h5>Install additional gems</h5>
   <p>
     To use this importer, you need to install these additional gems:
-    `gem install unidecode sequel mysql2 htmlentities`
+    `gem install unidecode sequel mysql2 htmlentities reverse_markdown`
   </p>
 </div>
 

--- a/site/_importers/s9ydatabase.md
+++ b/site/_importers/s9ydatabase.md
@@ -1,0 +1,46 @@
+---
+layout: docs
+title: S9Y
+prev_section: s9y
+link_source:  s9ydatabase
+next_section: textpattern
+permalink: /docs/s9ydatabase/
+---
+
+<div class="note info">
+  <h5>Install additional gems</h5>
+  <p>
+    To use this importer, you need to install these additional gems:
+    `gem install unidecode sequel mysql2 htmlentities`
+  </p>
+</div>
+
+
+To import your posts from a self-hosted [S9Y](http://www.s9y.org) database, run:
+
+{% highlight bash %}
+$ ruby -rubygems -e 'require "jekyll-import";
+    JekyllImport::Importers::S9YDatabase.run({
+      "dbname"   => "s9y_blog",
+      "user"     => "root",
+      "password" => "",
+      "host"     => "localhost",
+      "table_prefix"   => "serendipity_",
+      "clean_entities" => false,
+      "comments"       => true,
+      "categories"     => true,
+      "tags"           => true,
+      "extension"      => "html",
+      "export_drafts " => true,
+      "markdown"       => false
+    })
+{% endhighlight %}
+
+<div class="note info">
+  <h5>This only imports post &amp; page data &amp; content</h5>
+  <p>
+    This importer only converts your posts and creates YAML front-matter.
+    It does not import any layouts, styling, or external files
+    (images, CSS, etc.).
+  </p>
+</div>

--- a/site/_importers/s9ydatabase.md
+++ b/site/_importers/s9ydatabase.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: S9Y
+title: S9Y Database
 prev_section: s9y
 link_source:  s9ydatabase
 next_section: textpattern

--- a/site/_importers/s9ydatabase.md
+++ b/site/_importers/s9ydatabase.md
@@ -31,7 +31,7 @@ $ ruby -rubygems -e 'require "jekyll-import";
       "categories"     => true,
       "tags"           => true,
       "extension"      => "html",
-      "export_drafts " => true,
+      "drafts "        => true,
       "markdown"       => false,
       "permalinks"     => false
     })


### PR DESCRIPTION
Because I wanted to export my old blog and all I had was a MySQL dump, I created an `S9YDatabase` importer based on the [wordpress](http://import.jekyllrb.com/docs/wordpress/) importer.

Features:

- Export comments
- Export categories
- Export tags
- Export permalinks
- Reverse-markdown support