### PR TITLE
joomla3: allow importing drafts

### DIFF
--- a/lib/jekyll-import/importers/joomla3.rb
+++ b/lib/jekyll-import/importers/joomla3.rb
@@ -16,6 +16,7 @@ module JekyllImport
         c.option 'host', '--host', 'Database host name'
         c.option 'category', '--category', 'ID of the category'
         c.option 'prefix', '--prefix', 'Table prefix name'
+        c.option 'state', '--state', 'Which publishing state to select. 0: unpublished, 1: published, 2: archived (default: 1)'
       end
 
       def self.require_deps
@@ -34,10 +35,16 @@ module JekyllImport
         host    = options.fetch('host', "localhost")
         cid	    = options.fetch('category', 0)
         table_prefix = options.fetch('prefix', "jos_")
+        state   = options.fetch('state', 1)
 
         db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
-        FileUtils.mkdir_p("_posts")
+        if state == 0
+          directory = "_drafts"
+        else
+          directory = "_posts"
+        end
+        FileUtils.mkdir_p(directory)
 
         # Reads a MySQL database via Sequel and creates a post file for each
         # post in #__content that is published.
@@ -45,7 +52,7 @@ module JekyllImport
 		query << "`cn`.`created`, `cn`.`id`, `ct`.`title` AS `category`, `u`.`name` AS `author` "
 		query << "FROM `#{table_prefix}content` AS `cn` JOIN `#{table_prefix}categories` AS `ct` ON `cn`.`catid` = `ct`.`id` "
 		query << "JOIN `#{table_prefix}users` AS `u` ON `cn`.`created_by` = `u`.`id` "
-		query << "WHERE (`cn`.`state` = '1' OR `cn`.`state` = '2') " # Only published and archived content items to be imported
+		query << "WHERE `cn`.`state` = '#{state}' "
 
 		if cid > 0
 			query << " AND `cn`.`catid` = '#{cid}' "
@@ -58,12 +65,16 @@ module JekyllImport
           title = post[:title]
           slug = post[:alias]
           date = post[:created]
-		  author = post[:author]
-		  category = post[:category]
+          author = post[:author]
+          category = post[:category]
           content = post[:content]
-		  excerpt = post[:introtext]
-          name = "%02d-%02d-%02d-%s.markdown" % [date.year, date.month, date.day,
-                                                 slug]
+          excerpt = post[:introtext]
+          if state == 0
+            name = "%s.markdown" % [slug]
+          else
+            name = "%02d-%02d-%02d-%s.markdown" % [date.year, date.month, date.day,
+                                                   slug]
+          end
 
           # Get the relevant fields as a hash, delete empty fields and convert
           # to YAML for the header.
@@ -73,13 +84,13 @@ module JekyllImport
              'joomla_id' => post[:id],
              'joomla_url' => slug,
              'date' => date,
-			 'author' => author,
-			 'excerpt' => excerpt.strip.to_s,
-			 'category' => category
+             'author' => author,
+             'excerpt' => excerpt.strip.to_s,
+             'category' => category
            }.delete_if { |k,v| v.nil? || v == '' }.to_yaml
 
           # Write out the data and content to file
-          File.open("_posts/#{name}", "w") do |f|
+          File.open("#{directory}/#{name}", "w") do |f|
             f.puts data
             f.puts "---"
             f.puts content


### PR DESCRIPTION
Fix for issue #268. Also some whitespace cleanup (tabs and spaces where mixed beforehand).

This is a bit of a behaviour change in that it now only imports published articles by default, as opposed to both published and archived ones. But it can be rerun several times for several publishing states, so it shouldn't be much of an issue.
