### PR TITLE
Corrected Joomla3 importer name and clarified "category" field

### DIFF
--- a/_importers/joomla3.md
+++ b/_importers/joomla3.md
@@ -11,12 +11,12 @@ To import your posts from a [Joomla 3](http://joomla.org) installation, run:
 
 {% highlight bash %}
 $ ruby -rubygems -e 'require "jekyll-import";
-    JekyllImport::Importers::Joomla.run({
+    JekyllImport::Importers::Joomla3.run({
       "dbname"   => "name",
       "user"     => "myuser",
       "password" => "mypassword",
       "host"     => "myhost",
-      "category" => "category",
+      "category" => 0, # Category ID to import
       "prefix"   => "mytableprefix"
     })'
 {% endhighlight %}


### PR DESCRIPTION
The current documentation implies that the "category" field requires a string when it actually needs the id of the category to be selected.