### PR TITLE
Drupal 7: Remove uneeded double quote in SQL query

### DIFF
--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -26,7 +26,7 @@ module JekyllImport
                 WHERE (#{types})
                   AND n.nid = fdb.entity_id
                   AND n.vid = fdb.revision_id
-                GROUP BY n.nid"
+                GROUP BY n.nid
 EOS
 
         return query


### PR DESCRIPTION
Using EOS around the query means we dont need the trailing quote.