### PR TITLE
Updating Ruby and Jekyll versions for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
-    - JEKYLL_VERSION=3.3
     - JEKYLL_VERSION=3.0
-    - JEKYLL_VERSION=2.5.3
+    - JEKYLL_VERSION=2.5
 cache: bundler
 sudo: false
 before_script: bundle update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.3.1
   - 2.2
   - 2.1
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ env:
   matrix:
     - JEKYLL_VERSION=3.3
     - JEKYLL_VERSION=3.0
-    - JEKYLL_VERSION=2.5
-    - JEKYLL_VERSION=2.0
+    - JEKYLL_VERSION=2.5.3
 cache: bundler
 sudo: false
 before_script: bundle update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.3
   - 2.2
   - 2.1
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,16 @@
 language: ruby
 rvm:
+  - 2.3
   - 2.2
   - 2.1
-  - 2.0
-matrix:
-  include:
-    - # Ruby 1.9
-      rvm: 1.9
-      env: JEKYLL_VERSION=2.0
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
+    - JEKYLL_VERSION=3.3
     - JEKYLL_VERSION=3.0
     - JEKYLL_VERSION=2.5
+    - JEKYLL_VERSION=2.0
 cache: bundler
 sudo: false
 before_script: bundle update


### PR DESCRIPTION
Nokogiri no longer supports Ruby 1.9.3 it seems, causing tests to fail.

Given [1.9.3 is EOL](https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/), IMHO it should not longer be supported by this Gem.

Also, [2.0 is EOL](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/) so there is no point adding that. And it seems [2.3 and 2.4](https://docs.travis-ci.com/user/languages/ruby/#Supported-Ruby-Versions-and-RVM) are not available yet either.