### PR TITLE
WordPress: replace was backwards, broke end tags

### DIFF
--- a/lib/jekyll-import/importers/wordpress.rb
+++ b/lib/jekyll-import/importers/wordpress.rb
@@ -346,7 +346,7 @@ module JekyllImport
         text.gsub!("&gt;", ">")
         text.gsub!("&quot;", '"')
         text.gsub!("&apos;", "'")
-        text.gsub!("/", "&#47;")
+        text.gsub!("&#47;", "/")
         text
       end
 


### PR DESCRIPTION
The substitution was not being made because the arguments were reversed. This resulted in breaking HTML end tags imported from WordPress. The issue reporting this was closed due to inactivity, I've just now had some time to try to use Jekyll again.