### PR TITLE
WordPressDotCom: import post passwords

### DIFF
--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -84,6 +84,10 @@ module JekyllImport
         def status
           @status ||= text_for('wp:status')
         end
+      
+        def password
+          @post_password ||= text_for('wp:post_password')
+        end
 
         def post_type
           @post_type ||= text_for('wp:post_type')
@@ -162,6 +166,7 @@ module JekyllImport
             'date'       => item.published_at,
             'type'       => item.post_type,
             'published'  => item.published?,
+            'password'   => item.password,
             'status'     => item.status,
             'categories' => categories,
             'tags'       => tags,


### PR DESCRIPTION
Imports passwords of password protected posts.

Again, I found this super useful, but feel free to decline if you don't want it 😄 