### PR TITLE
Ghost: import drafts & pages, and fix issue with date extraction

### DIFF
--- a/lib/jekyll-import/importers/ghost.rb
+++ b/lib/jekyll-import/importers/ghost.rb
@@ -59,7 +59,8 @@ module JekyllImport
           'layout' => page ? 'page' : 'post',
           'title' => post[:title]
         }
-        frontmatter['date'] = date if !draft # only add the date to the frontmatter when the post is published
+        frontmatter['date'] = date if !page && !draft # only add the date to the frontmatter when the post is published
+        frontmatter['published'] = false if page && draft # set published to false for draft pages
         frontmatter.delete_if { |k,v| v.nil? || v == '' } # removes empty fields
 
         # write the posts to disk

--- a/lib/jekyll-import/importers/ghost.rb
+++ b/lib/jekyll-import/importers/ghost.rb
@@ -29,7 +29,7 @@ module JekyllImport
       private
       def self.fetch_posts(dbfile)
         db = Sequel.sqlite(dbfile)
-        query = "SELECT `title`, `slug`, `markdown`, `created_at`, `status` FROM posts"
+        query = "SELECT `title`, `slug`, `markdown`, `created_at`, `published_at`, `status` FROM posts"
         db[query]
       end
 
@@ -37,9 +37,8 @@ module JekyllImport
         # detect if the post is a draft
         draft = post[:status].eql?('draft')
 
-        # Ghost saves the time in an weird format with 3 more numbers.
-        # But the time is correct when we remove the last 3 numbers.
-        date = Time.at(post[:created_at].to_i.to_s[0..-4].to_i)
+        # the publish date if the post has been published, creation date otherwise
+        date = Time.at(post[draft ? :created_at : :published_at].to_i)
 
         # the directory where the file will be saved to. either _drafts or _posts
         directory = draft ? "_drafts" : "_posts"


### PR DESCRIPTION
This PR adds a few improvements to the Ghost importer.

 - The note about weird Ghost date formats seems to no longer apply. When run against a current Ghost installation (tested with 0.11), all dates end up as 1970-01-01 because of the special trimming. This has been removed.
 - If a post has been published, the importer now uses its publish date instead of its creation date.
 - The importer now imports pages using slug-only filenames in the root directory with the 'page' layout.