### PR TITLE
WordPress: fix variable name for `more_anchor`

### DIFF
--- a/lib/jekyll-import/importers/wordpress.rb
+++ b/lib/jekyll-import/importers/wordpress.rb
@@ -201,7 +201,7 @@ module JekyllImport
             excerpt = content[0...more_index]
           end
           if options[:more_anchor]
-            more_link = "more"
+            more_anchor = "more"
             content.sub!(/<!-- *more *-->/,
                          "<a id=\"more\"></a>" +
                          "<a id=\"more-#{post[:id]}\"></a>")


### PR DESCRIPTION
In the WordPress importer, the `more_link` variable was never used so this option wasn't really doing anything (always passing `nil`).