### PR TITLE
Use mysql2 instead of mysql in Joomla3 importer

### DIFF
--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -48,7 +48,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('sequel', "~> 3.42")
   s.add_development_dependency('htmlentities', "~> 4.3")
   s.add_development_dependency('hpricot', "~> 0.8")
-  s.add_development_dependency('mysql', "~> 2.8")
   s.add_development_dependency('pg', "~> 0.12")
   s.add_development_dependency('mysql2', "~> 0.3")
   s.add_development_dependency('behance', "~> 0.3")

--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('hpricot', "~> 0.8")
   s.add_development_dependency('pg', "~> 0.12")
   s.add_development_dependency('mysql2', "~> 0.3")
+  s.add_development_dependency('sqlite3', "~> 1.3.13")
   s.add_development_dependency('behance', "~> 0.3")
   s.add_development_dependency('unidecode')
   s.add_development_dependency('open_uri_redirections')

--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -32,6 +32,7 @@ module JekyllImport
           JekyllImport.require_with_fallback(%w[
             rubygems
             sequel
+            mysql2
             fileutils
             safe_yaml
           ])
@@ -45,7 +46,7 @@ module JekyllImport
           prefix = options.fetch('prefix',   DEFAULTS["prefix"])
           types  = options.fetch('types',    DEFAULTS["types"])
 
-          db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+          db = Sequel.mysql2(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
           query = self.build_query(prefix, types)
 

--- a/lib/jekyll-import/importers/easyblog.rb
+++ b/lib/jekyll-import/importers/easyblog.rb
@@ -20,11 +20,12 @@ module JekyllImport
 
       def self.require_deps
         JekyllImport.require_with_fallback(%w[
-                                           rubygems
-                                          sequel
-                                          fileutils
-                                          safe_yaml
-                                          ])
+          rubygems
+          sequel
+          mysql2
+          fileutils
+          safe_yaml
+        ])
       end
 
       def self.process(options)
@@ -35,7 +36,7 @@ module JekyllImport
         section = options.fetch('section', '1')
         table_prefix = options.fetch('prefix', "jos_")
 
-        db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+        db = Sequel.mysql2(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
         FileUtils.mkdir_p("_posts")
 

--- a/lib/jekyll-import/importers/ghost.rb
+++ b/lib/jekyll-import/importers/ghost.rb
@@ -10,6 +10,7 @@ module JekyllImport
         JekyllImport.require_with_fallback(%w[
           rubygems
           sequel
+          sqlite3
           fileutils
           safe_yaml
         ])

--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -25,7 +25,6 @@ module JekyllImport
           mysql2
           fileutils
           safe_yaml
-          mysql
         ])
       end
 

--- a/lib/jekyll-import/importers/joomla3.rb
+++ b/lib/jekyll-import/importers/joomla3.rb
@@ -24,6 +24,7 @@ module JekyllImport
           sequel
           fileutils
           safe_yaml
+          mysql2
         ])
       end
 
@@ -35,7 +36,7 @@ module JekyllImport
         cid	    = options.fetch('category', 0)
         table_prefix = options.fetch('prefix', "jos_")
 
-        db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+        db = Sequel.mysql2(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
         FileUtils.mkdir_p("_posts")
 

--- a/lib/jekyll-import/importers/joomla3.rb
+++ b/lib/jekyll-import/importers/joomla3.rb
@@ -22,9 +22,9 @@ module JekyllImport
         JekyllImport.require_with_fallback(%w[
           rubygems
           sequel
+          mysql2
           fileutils
           safe_yaml
-          mysql2
         ])
       end
 

--- a/lib/jekyll-import/importers/mephisto.rb
+++ b/lib/jekyll-import/importers/mephisto.rb
@@ -30,6 +30,7 @@ module JekyllImport
         JekyllImport.require_with_fallback(%w[
           rubygems
           sequel
+          mysql2
           fastercsv
           fileutils
         ])
@@ -62,10 +63,10 @@ module JekyllImport
         pass   = options.fetch('password', '')
         host   = options.fetch('host', "localhost")
 
-        db = Sequel.mysql(dbname, :user => user,
-                                  :password => pass,
-                                  :host => host,
-                                  :encoding => 'utf8')
+        db = Sequel.mysql2(dbname, :user => user,
+                                   :password => pass,
+                                   :host => host,
+                                   :encoding => 'utf8')
 
         FileUtils.mkdir_p "_posts"
 

--- a/lib/jekyll-import/importers/mt.rb
+++ b/lib/jekyll-import/importers/mt.rb
@@ -22,6 +22,9 @@ module JekyllImport
         JekyllImport.require_with_fallback(%w[
           rubygems
           sequel
+          sqlite3
+          mysql2
+          pg
           fileutils
           safe_yaml
         ])
@@ -230,8 +233,9 @@ module JekyllImport
       end
 
       def self.database_from_opts(options)
-        engine   = options.fetch('engine', 'mysql')
-        dbname   = options.fetch('dbname')
+        engine        = options.fetch('engine', 'mysql')
+        dbname        = options.fetch('dbname')
+        sequel_engine = engine == 'mysql' ? 'mysql2' : engine
 
         case engine
         when "sqlite"
@@ -244,7 +248,7 @@ module JekyllImport
           }
           db_connect_opts = options['port'] if options['port']
           Sequel.public_send(
-            engine,
+            sequel_engine,
             dbname,
             db_connect_opts
           )

--- a/lib/jekyll-import/importers/textpattern.rb
+++ b/lib/jekyll-import/importers/textpattern.rb
@@ -18,6 +18,7 @@ module JekyllImport
         JekyllImport.require_with_fallback(%w[
           rubygems
           sequel
+          mysql2
           fileutils
           safe_yaml
         ])
@@ -36,7 +37,7 @@ module JekyllImport
         pass   = options.fetch('password', "")
         host   = options.fetch('host', "localhost")
 
-        db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+        db = Sequel.mysql2(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
         FileUtils.mkdir_p "_posts"
 

--- a/lib/jekyll-import/importers/typo.rb
+++ b/lib/jekyll-import/importers/typo.rb
@@ -21,6 +21,8 @@ module JekyllImport
         JekyllImport.require_with_fallback(%w[
           rubygems
           sequel
+          mysql2
+          pg
           fileutils
           safe_yaml
         ])
@@ -46,7 +48,7 @@ module JekyllImport
         when :postgres
           db = Sequel.postgres(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
         when :mysql
-          db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+          db = Sequel.mysql2(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
         else
           raise "Unknown database server '#{server}'"
         end


### PR DESCRIPTION
Use and require mysql2 gem instead of mysql for the Joomla3 importer. Change similar to the one for the Joomla importer - #255.