### PR TITLE
Add option to specify the MySQL port for the Joomla importers

### DIFF
--- a/docs/_importers/joomla.md
+++ b/docs/_importers/joomla.md
@@ -16,12 +16,12 @@ $ ruby -rubygems -e 'require "jekyll-import";
       "user"     => "myuser",
       "password" => "mypassword",
       "host"     => "myhost",
-      "port"     => "port",
+      "port"     => portnumber,
       "section"  => "thesection",
       "prefix"   => "mytableprefix"
     })'
 {% endhighlight %}
 
 The only required fields are `dbname` and `user`. `password` defaults to `""`,
-`host` defaults to `"localhost"`, `port` defaults to `"3306"`, `section`
+`host` defaults to `"localhost"`, `portnumber` defaults to `3306`, `section`
 defaults to `"1"` and `prefix` defaults to `"jos_"`.

--- a/docs/_importers/joomla.md
+++ b/docs/_importers/joomla.md
@@ -16,11 +16,12 @@ $ ruby -rubygems -e 'require "jekyll-import";
       "user"     => "myuser",
       "password" => "mypassword",
       "host"     => "myhost",
+      "port"     => "port",
       "section"  => "thesection",
       "prefix"   => "mytableprefix"
     })'
 {% endhighlight %}
 
 The only required fields are `dbname` and `user`. `password` defaults to `""`,
-`host` defaults to `"localhost"`, and `section` defaults to `"1"` and `prefix`
-defaults to `"jos_"`.
+`host` defaults to `"localhost"`, `port` defaults to `"3306"`, `section`
+defaults to `"1"` and `prefix` defaults to `"jos_"`.

--- a/docs/_importers/joomla3.md
+++ b/docs/_importers/joomla3.md
@@ -16,13 +16,15 @@ $ ruby -rubygems -e 'require "jekyll-import";
       "user"     => "myuser",
       "password" => "mypassword",
       "host"     => "myhost",
+      "port"     => "port",
       "category" => category,
       "prefix"   => "mytableprefix"
     })'
 {% endhighlight %}
 
 The only required fields are `dbname`, `prefix` and `user`. `password` defaults to `""`,
-and `host` defaults to `"localhost"`.
+`host` defaults to `"localhost"`, `port` defaults to `"3306"` and `prefix` defaults to
+`"jos_"`.
 
 If the `category` numerical field is not filled, all articles will be imported, except the ones that are 
 uncategorized. 

--- a/docs/_importers/joomla3.md
+++ b/docs/_importers/joomla3.md
@@ -16,14 +16,14 @@ $ ruby -rubygems -e 'require "jekyll-import";
       "user"     => "myuser",
       "password" => "mypassword",
       "host"     => "myhost",
-      "port"     => "port",
+      "port"     => portnumber,
       "category" => category,
       "prefix"   => "mytableprefix"
     })'
 {% endhighlight %}
 
 The only required fields are `dbname`, `prefix` and `user`. `password` defaults to `""`,
-`host` defaults to `"localhost"`, `port` defaults to `"3306"` and `prefix` defaults to
+`host` defaults to `"localhost"`, `portnumber` defaults to `3306` and `prefix` defaults to
 `"jos_"`.
 
 If the `category` numerical field is not filled, all articles will be imported, except the ones that are 

--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -14,6 +14,7 @@ module JekyllImport
         c.option 'user', '--user', 'Database user name'
         c.option 'password', '--password', "Database user's password (default: '')"
         c.option 'host', '--host', 'Database host name'
+        c.option 'port', '--port', 'Database port'
         c.option 'section', '--section', 'Table prefix name'
         c.option 'prefix', '--prefix', 'Table prefix name'
       end
@@ -32,11 +33,12 @@ module JekyllImport
         dbname  = options.fetch('dbname')
         user    = options.fetch('user')
         pass    = options.fetch('password', '')
-        host    = options.fetch('host', "localhost")
+        host    = options.fetch('host', 'localhost')
+        port    = options.fetch('port', '3306')
         section = options.fetch('section', '1')
-        table_prefix = options.fetch('prefix', "jos_")
+        table_prefix = options.fetch('prefix', 'jos_')
 
-        db = Sequel.mysql2(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+        db = Sequel.mysql2(dbname, user: user, password: pass, host: host, port: port, encoding: 'utf8')
 
         FileUtils.mkdir_p("_posts")
 

--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -34,7 +34,7 @@ module JekyllImport
         user    = options.fetch('user')
         pass    = options.fetch('password', '')
         host    = options.fetch('host', 'localhost')
-        port    = options.fetch('port', '3306')
+        port    = options.fetch('port', 3306).to_i
         section = options.fetch('section', '1')
         table_prefix = options.fetch('prefix', 'jos_')
 

--- a/lib/jekyll-import/importers/joomla3.rb
+++ b/lib/jekyll-import/importers/joomla3.rb
@@ -14,6 +14,7 @@ module JekyllImport
         c.option 'user', '--user', 'Database user name'
         c.option 'password', '--password', "Database user's password (default: '')"
         c.option 'host', '--host', 'Database host name'
+        c.option 'port', '--port', 'Database port'
         c.option 'category', '--category', 'ID of the category'
         c.option 'prefix', '--prefix', 'Table prefix name'
       end
@@ -32,11 +33,12 @@ module JekyllImport
         dbname  = options.fetch('dbname')
         user    = options.fetch('user')
         pass    = options.fetch('password', '')
-        host    = options.fetch('host', "localhost")
+        host    = options.fetch('host', 'localhost')
+        port    = options.fetch('port', '3306')
         cid	    = options.fetch('category', 0)
-        table_prefix = options.fetch('prefix', "jos_")
+        table_prefix = options.fetch('prefix', 'jos_')
 
-        db = Sequel.mysql2(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
+        db = Sequel.mysql2(dbname, user: user, password: pass, host: host, port: port, encoding: 'utf8')
 
         FileUtils.mkdir_p("_posts")
 

--- a/lib/jekyll-import/importers/joomla3.rb
+++ b/lib/jekyll-import/importers/joomla3.rb
@@ -34,7 +34,7 @@ module JekyllImport
         user    = options.fetch('user')
         pass    = options.fetch('password', '')
         host    = options.fetch('host', 'localhost')
-        port    = options.fetch('port', '3306')
+        port    = options.fetch('port', 3306).to_i
         cid	    = options.fetch('category', 0)
         table_prefix = options.fetch('prefix', 'jos_')
 


### PR DESCRIPTION
* Add option to specify the MySQL port for the Joomla importers
* Use Ruby 1.9 hash syntax
* Update the Joomla importers documentation