### PR TITLE
Use mysql by default in Drupal importers.

### DIFF
--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -42,7 +42,7 @@ module JekyllImport
         end
 
         def process(options)
-          engine = options.fetch("engine")
+          engine = options.fetch("engine",   DEFAULTS["engine"])
           dbname = options.fetch("dbname")
           user   = options.fetch("user")
           pass   = options.fetch("password", DEFAULTS["password"])


### PR DESCRIPTION
#331 added support for PostgreSQL in the Drupal importers. According to the documentation, MySQL is supposed to be the default engine, but the `engine` parameter is now mandatory because the default value is not used. This PR fixes that by using the value that was added to the `DEFAULTS` hash.

/cc @kesara 