### PR TITLE
Column name typo

### DIFF
--- a/lib/jekyll-import/importers/mt.rb
+++ b/lib/jekyll-import/importers/mt.rb
@@ -82,7 +82,7 @@ module JekyllImport
         posts = posts.filter(:entry_blog_id => options["blog_id"]) if options["blog_id"]
         posts.each do |post|
           categories = post_categories.filter(
-            :mt_placement__placement_entry_id => post[:entry_id]
+            :placement_entry_id => post[:entry_id]
           ).map { |ea| encode(ea[:category_basename], options) }
 
           file_name = post_file_name(post, options)


### PR DESCRIPTION
Fixing the error :

/Library/Ruby/Gems/2.3.0/gems/mysql2-0.5.1/lib/mysql2/client.rb:131:in `_query': Mysql2::Error: Unknown column 'mt_placement__placement_entry_id' in 'where clause' (Sequel::DatabaseError)