### PR TITLE
Replace uninitialized constant with alternative

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,6 @@ AllCops:
     - script/**/*
     - test/**/*
     - vendor/**/*
-    - jekyll-import.gemspec
     - Rakefile
 
 Lint/NestedMethodDefinition:

--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 lib = File.expand_path("lib", __dir__)
@@ -23,7 +22,7 @@ Gem::Specification.new do |s|
   s.email    = "tom@mojombo.com"
   s.homepage = "http://github.com/jekyll/jekyll-import"
 
-  s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(%r!^lib/!)
+  s.files         = `git ls-files`.split($/).grep(%r!^lib/!)
   s.require_paths = %w(lib)
 
   s.rdoc_options = ["--charset=UTF-8"]


### PR DESCRIPTION
`$INPUT_RECORD_SEPARATOR` requires loading `"english"` from Ruby stdlib to initialize it.
So, its better remove the warning from Ruby by using the pre-initialized alternative `$/` especially since Rubocop does not complain about it now..