### PR TITLE
Remove cyclic require of import command

### DIFF
--- a/lib/jekyll/commands/import.rb
+++ b/lib/jekyll/commands/import.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-# load from jekyll-import/lib
-$LOAD_PATH.unshift File.expand_path("../", __dir__)
-require "jekyll/command"
-require "jekyll-import"
-
 module Jekyll
   module Commands
     class Import < Command


### PR DESCRIPTION
```
require "jekyll-import" > require "jekyll/commands/import" > require "jekyll-import" ...
```