### PR TITLE
Replace syntax highlighting with a better CSS set

### DIFF
--- a/docs/_sass/pygments.scss
+++ b/docs/_sass/pygments.scss
@@ -1,70 +1,70 @@
-/*.highlight  { background: #333333; color: #ffffff}*/
-.highlight .hll { background-color: #ffffcc }
-.highlight .c { color: #87ceeb} /* Comment */
-.highlight .err { color: #ffffff} /* Error */
-.highlight .g { color: #ffffff} /* Generic */
-.highlight .k { color: #f0e68c} /* Keyword */
-.highlight .l { color: #ffffff} /* Literal */
-.highlight .n { color: #ffffff} /* Name */
-.highlight .o { color: #ffffff} /* Operator */
-.highlight .x { color: #ffffff} /* Other */
-.highlight .p { color: #ffffff} /* Punctuation */
-.highlight .cm { color: #87ceeb} /* Comment.Multiline */
-.highlight .cp { color: #cd5c5c} /* Comment.Preproc */
-.highlight .c1 { color: #87ceeb} /* Comment.Single */
-.highlight .cs { color: #87ceeb} /* Comment.Special */
-.highlight .gd { color: #0000c0; font-weight: bold; background-color: #008080 } /* Generic.Deleted */
-.highlight .ge { color: #c000c0; text-decoration: underline} /* Generic.Emph */
-.highlight .gr { color: #c0c0c0; font-weight: bold; background-color: #c00000 } /* Generic.Error */
-.highlight .gh { color: #cd5c5c} /* Generic.Heading */
-.highlight .gi { color: #ffffff; background-color: #0000c0 } /* Generic.Inserted */
-.highlight span.go { color: #add8e6; font-weight: bold; background-color: #4d4d4d } /* Generic.Output, qualified with span to prevent applying this style to the Go language, see #1153. */
-.highlight .gp { color: #ffffff} /* Generic.Prompt */
-.highlight .gs { color: #ffffff} /* Generic.Strong */
-.highlight .gu { color: #cd5c5c} /* Generic.Subheading */
-.highlight .gt { color: #c0c0c0; font-weight: bold; background-color: #c00000 } /* Generic.Traceback */
-.highlight .kc { color: #f0e68c} /* Keyword.Constant */
-.highlight .kd { color: #f0e68c} /* Keyword.Declaration */
-.highlight .kn { color: #f0e68c} /* Keyword.Namespace */
-.highlight .kp { color: #f0e68c} /* Keyword.Pseudo */
-.highlight .kr { color: #f0e68c} /* Keyword.Reserved */
-.highlight .kt { color: #bdb76b} /* Keyword.Type */
-.highlight .ld { color: #ffffff} /* Literal.Date */
-.highlight .m { color: #ffffff} /* Literal.Number */
-.highlight .s { color: #ffffff} /* Literal.String */
-.highlight .na { color: #ffffff} /* Name.Attribute */
-.highlight .nb { color: #ffffff} /* Name.Builtin */
-.highlight .nc { color: #ffffff} /* Name.Class */
-.highlight .no { color: #ffa0a0} /* Name.Constant */
-.highlight .nd { color: #ffffff} /* Name.Decorator */
-.highlight .ni { color: #ffdead} /* Name.Entity */
-.highlight .ne { color: #ffffff} /* Name.Exception */
-.highlight .nf { color: #ffffff} /* Name.Function */
-.highlight .nl { color: #ffffff} /* Name.Label */
-.highlight .nn { color: #ffffff} /* Name.Namespace */
-.highlight .nx { color: #ffffff} /* Name.Other */
-.highlight .py { color: #ffffff} /* Name.Property */
-.highlight .nt { color: #f0e68c} /* Name.Tag */
-.highlight .nv { color: #98fb98} /* Name.Variable */
-.highlight .ow { color: #ffffff} /* Operator.Word */
-.highlight .w { color: #ffffff} /* Text.Whitespace */
-.highlight .mf { color: #ffffff} /* Literal.Number.Float */
-.highlight .mh { color: #ffffff} /* Literal.Number.Hex */
-.highlight .mi { color: #ffffff} /* Literal.Number.Integer */
-.highlight .mo { color: #ffffff} /* Literal.Number.Oct */
-.highlight .sb { color: #ffffff} /* Literal.String.Backtick */
-.highlight .sc { color: #ffffff} /* Literal.String.Char */
-.highlight .sd { color: #ffffff} /* Literal.String.Doc */
-.highlight .s2 { color: #ffffff} /* Literal.String.Double */
-.highlight .se { color: #ffffff} /* Literal.String.Escape */
-.highlight .sh { color: #ffffff} /* Literal.String.Heredoc */
-.highlight .si { color: #ffffff} /* Literal.String.Interpol */
-.highlight .sx { color: #ffffff} /* Literal.String.Other */
-.highlight .sr { color: #ffffff} /* Literal.String.Regex */
-.highlight .s1 { color: #ffffff} /* Literal.String.Single */
-.highlight .ss { color: #ffffff} /* Literal.String.Symbol */
-.highlight .bp { color: #ffffff} /* Name.Builtin.Pseudo */
-.highlight .vc { color: #98fb98} /* Name.Variable.Class */
-.highlight .vg { color: #98fb98} /* Name.Variable.Global */
-.highlight .vi { color: #98fb98} /* Name.Variable.Instance */
-.highlight .il { color: #ffffff} /* Literal.Number.Integer.Long */
+.highlight {
+  pre, code { line-height: 1.45em }
+}
+
+.highlight { background: #333333; color: #ffffff }
+.highlight .hll { background-color: #272822; }
+.highlight .err { color: #960050; background-color: #1e0010 } /* Error */
+
+.highlight .c  { color: #75715e } /* Comment */
+.highlight .k  { color: #ff3a81 } /* Keyword */
+.highlight .l  { color: #ae81ff } /* Literal */
+.highlight .n  { color: #f8f8f2 } /* Name */
+.highlight .o  { color: #ffffff } /* Operator */
+.highlight .p  { color: #f8f8f2 } /* Punctuation */
+.highlight .cm { color: #75715e } /* Comment.Multiline */
+.highlight .cp { color: #75715e } /* Comment.Preproc */
+.highlight .c1 { color: #999999 } /* Comment.Single */
+.highlight .cs { color: #75715e } /* Comment.Special */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .kc { color: #66d9ef } /* Keyword.Constant */
+.highlight .kd { color: #66d9ef } /* Keyword.Declaration */
+.highlight .kn { color: #f92672 } /* Keyword.Namespace */
+.highlight .kp { color: #66d9ef } /* Keyword.Pseudo */
+.highlight .kr { color: #66d9ef } /* Keyword.Reserved */
+.highlight .kt { color: #66d9ef } /* Keyword.Type */
+.highlight .ld { color: #e6db74 } /* Literal.Date */
+.highlight .m  { color: #ae81ff } /* Literal.Number */
+.highlight .s  { color: #e6db74 } /* Literal.String */
+.highlight .na { color: #a6e22e } /* Name.Attribute */
+.highlight .nb { color: #f8f8f2 } /* Name.Builtin */
+.highlight .nc { color: #a6e22e } /* Name.Class */
+.highlight .no { color: #66d9ef } /* Name.Constant */
+.highlight .nd { color: #a6e22e } /* Name.Decorator */
+.highlight .ni { color: #f8f8f2 } /* Name.Entity */
+.highlight .ne { color: #a6e22e } /* Name.Exception */
+.highlight .nf { color: #a6e22e } /* Name.Function */
+.highlight .nl { color: #f8f8f2 } /* Name.Label */
+.highlight .nn { color: #f8f8f2 } /* Name.Namespace */
+.highlight .nx { color: #a6e22e } /* Name.Other */
+.highlight .py { color: #f8f8f2 } /* Name.Property */
+.highlight .nt { color: #f92672 } /* Name.Tag */
+.highlight .nv { color: #f8f8f2 } /* Name.Variable */
+.highlight .ow { color: #f92672 } /* Operator.Word */
+.highlight .w  { color: #f8f8f2 } /* Text.Whitespace */
+.highlight .mf { color: #ae81ff } /* Literal.Number.Float */
+.highlight .mh { color: #ae81ff } /* Literal.Number.Hex */
+.highlight .mi { color: #ae81ff } /* Literal.Number.Integer */
+.highlight .mo { color: #ae81ff } /* Literal.Number.Oct */
+.highlight .sb { color: #e6db74 } /* Literal.String.Backtick */
+.highlight .sc { color: #e6db74 } /* Literal.String.Char */
+.highlight .sd { color: #e6db74 } /* Literal.String.Doc */
+.highlight .s2 { color: #e6db74 } /* Literal.String.Double */
+.highlight .se { color: #ae81ff } /* Literal.String.Escape */
+.highlight .sh { color: #e6db74 } /* Literal.String.Heredoc */
+.highlight .si { color: #e6db74 } /* Literal.String.Interpol */
+.highlight .sx { color: #e6db74 } /* Literal.String.Other */
+.highlight .sr { color: #e6db74 } /* Literal.String.Regex */
+.highlight .s1 { color: #e6db74 } /* Literal.String.Single */
+.highlight .ss { color: #b286f9 } /* Literal.String.Symbol */
+.highlight .bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #f8f8f2 } /* Name.Variable.Class */
+.highlight .vg { color: #f8f8f2 } /* Name.Variable.Global */
+.highlight .vi { color: #f8f8f2 } /* Name.Variable.Instance */
+.highlight .il { color: #ae81ff } /* Literal.Number.Integer.Long */
+
+.highlight .gh { } /* Generic Heading & Diff Header */
+.highlight .gu { color: #75715e; } /* Generic.Subheading & Diff Unified/Comment? */
+.highlight .gd { color: #f92672; } /* Generic.Deleted & Diff Deleted */
+.highlight .gi { color: #a6e22e; } /* Generic.Inserted & Diff Inserted */


### PR DESCRIPTION
Based on https://github.com/jwarby/jekyll-pygments-themes/blob/master/monokai.css
Demo src: https://import.jekyllrb.com/docs/contributing/#creating-a-new-importer

### Before:
![before change](https://user-images.githubusercontent.com/12479464/47011302-3a98f080-d15f-11e8-99b7-849c6d7c540c.png)

### After:
![after change](https://user-images.githubusercontent.com/12479464/47013524-1809d600-d165-11e8-9e26-031e65afede3.png)
