### PR TITLE
Unfreeze strings in importers that modify literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,6 @@ AllCops:
     - test/**/*
     - vendor/**/*
     - Rakefile
+Style/MutableConstant:
+  Exclude:
+    - lib/jekyll-import/importers/typo.rb

--- a/lib/jekyll-import/importers/blogger.rb
+++ b/lib/jekyll-import/importers/blogger.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 module JekyllImport
   module Importers

--- a/lib/jekyll-import/importers/joomla3.rb
+++ b/lib/jekyll-import/importers/joomla3.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 module JekyllImport
   module Importers

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 module JekyllImport
   module Importers

--- a/lib/jekyll-import/importers/tumblr.rb
+++ b/lib/jekyll-import/importers/tumblr.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 module JekyllImport
   module Importers

--- a/lib/jekyll-import/importers/typo.rb
+++ b/lib/jekyll-import/importers/typo.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 module JekyllImport
   module Importers

--- a/lib/jekyll-import/importers/wordpress.rb
+++ b/lib/jekyll-import/importers/wordpress.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 module JekyllImport
   module Importers
@@ -163,10 +163,10 @@ module JekyllImport
 
         if options[:status] && !options[:status].empty?
           status = options[:status][0]
-          +posts_query << "
+          posts_query << "
            WHERE posts.post_status = '#{status}'"
           options[:status][1..-1].each do |post_status|
-            +posts_query << " OR
+            posts_query << " OR
              posts.post_status = '#{post_status}'"
           end
         end


### PR DESCRIPTION
These importers modify string literals in various places.
It is easier and cleaner to simply disable `frozen_string_literal` pragma for these importers

Resolves #380 