### PR TITLE
Convert HTML to MD with ReverseMarkdown instead

### DIFF
--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("fastercsv", "~> 1.0")
   s.add_runtime_dependency("jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.0")
   s.add_runtime_dependency("nokogiri", "~> 1.0")
+  s.add_runtime_dependency("reverse_markdown", "~> 1.0")
 
   # development dependencies
   s.add_development_dependency("activesupport", "~> 4.2")
@@ -53,7 +54,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("mysql2", "~> 0.3")
   s.add_development_dependency("open_uri_redirections", "~> 0.2")
   s.add_development_dependency("pg", "~> 0.12")
-  s.add_development_dependency("reverse_markdown", "~> 1.0")
   s.add_development_dependency("sequel", "~> 3.42")
   s.add_development_dependency("sqlite3", "~> 1.3")
   s.add_development_dependency("unidecode", "~> 1.0")

--- a/lib/jekyll-import/importers/tumblr.rb
+++ b/lib/jekyll-import/importers/tumblr.rb
@@ -14,6 +14,7 @@ module JekyllImport
             uri
             time
             jekyll
+            reverse_markdown
           ))
         end
 
@@ -239,11 +240,7 @@ module JekyllImport
             content.gsub!(%r!</#{tag}!i, "||#{tag}")
           end
 
-          content = Kramdown::Document.new(
-            content,
-            :input      => "html",
-            :line_width => 90
-          ).to_kramdown
+          content = ReverseMarkdown.convert(content)
 
           preserve.each do |tag|
             content.gsub!("$$#{tag}", "<#{tag}")

--- a/test/test_tumblr_importer.rb
+++ b/test/test_tumblr_importer.rb
@@ -278,26 +278,25 @@ class TestTumblrImporter < Test::Unit::TestCase
           This is a paragraph that contains a variety of formatted text.
           Simply put, <b>bold</b> &amp; <strong>strong</strong> appear thicker than the regular
           text. A text in <i>italics</i> denotes <em>emphasis</em> with a slight slant from the
-          vertical axis. A <a href="#">link</a> points to a reference elsewhere and is usually
-          underlined.
+          vertical axis. A <a href="http://example.com">link</a> points to a reference elsewhere
+          and is usually underlined.
         </p>
         <p>
           Images are generally embedded by using the <code>&lt;img&gt;</code> tag and render
           directly like this duck: <img src="img/duck.png" alt="Quack!"/>
         </p>
+        <p>
+          Frais pour l'hiver.
+        </p>
       HTML
-      output = <<~MKDWN
-        # A Test Post
 
-        This is a paragraph that contains a variety of formatted text. Simply put, **bold** &amp;
-        **strong** appear thicker than the regular text. A text in *italics* denotes *emphasis*
-        with a slight slant from the vertical axis. A [link](#) points to a reference elsewhere
-        and is usually underlined.
+      output = "# A Test Post\n\nThis is a paragraph that contains a variety of formatted text. " \
+               "Simply put, **bold** & **strong** appear thicker than the regular text. A text " \
+               "in _italics_ denotes _emphasis_ with a slight slant from the vertical axis. A " \
+               "[link](http://example.com) points to a reference elsewhere and is usually under" \
+               "lined.\n\nImages are generally embedded by using the `<img>` tag and render " \
+               "directly like this duck: ![Quack!](img/duck.png)\n\nFrais pour l'hiver.\n\n"
 
-        Images are generally embedded by using the `<img>` tag and render directly like this duck:
-        ![Quack!](img/duck.png)
-
-      MKDWN
       assert_equal(output, Importers::Tumblr.html_to_markdown(input))
     end
   end


### PR DESCRIPTION
Since `reverse_markdown` with default configuration handles quotes and special entities (`&`) better than Kramdown. This is all that is required for typical tumblr blogs.