### PR TITLE
Replace URI.parse.open with OpenURI.open_uri

### DIFF
--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -38,7 +38,7 @@ module JekyllImport
             next
           end
           begin
-            URI.parse(uri, :allow_redirections => :safe).open do |f|
+            OpenURI.open_uri(uri, :allow_redirections => :safe) do |f|
               File.open(dst, "wb") do |out|
                 out.puts f.read
               end


### PR DESCRIPTION
`URI.parse` takes only one argument unlike `Kernel#open` as evident from the original `:open` replaced in https://github.com/jekyll/jekyll-import/commit/a23329709018deec7d821c2b23daef68d970e090. The `:allow_redirections` option is made available by the `open_uri_redirections` gem.

Replacing `URI.parse.open` here with a heavy-duty `OpenURI.open_uri` to allow reading the given uri along with `:allow_redirections` option and avoid raising a security flag from RuboCop

Resolves #387 