### PR TITLE
ghost.db stores timestamps in ms, not seconds. Fixed the ghost importer.

### DIFF
--- a/lib/jekyll-import/importers/ghost.rb
+++ b/lib/jekyll-import/importers/ghost.rb
@@ -45,7 +45,9 @@ module JekyllImport
           page = post[:page]
 
           # the publish date if the post has been published, creation date otherwise
-          date = Time.at(post[draft ? :created_at : :published_at].to_i / 1000) # the db stores timestamps in ms, so we need too divide by 1000
+          # The database stores timestamps in milliseconds, so we need to divide by 1000
+          # to get time in seconds.
+          date = Time.at(post[draft ? :created_at : :published_at].to_i / 1000)
 
           if page
             # the filename under which the page is stored

--- a/lib/jekyll-import/importers/ghost.rb
+++ b/lib/jekyll-import/importers/ghost.rb
@@ -45,7 +45,7 @@ module JekyllImport
           page = post[:page]
 
           # the publish date if the post has been published, creation date otherwise
-          date = Time.at(post[draft ? :created_at : :published_at].to_i)
+          date = Time.at(post[draft ? :created_at : :published_at].to_i / 1000) # the db stores timestamps in ms, so we need too divide by 1000
 
           if page
             # the filename under which the page is stored


### PR DESCRIPTION
fixed it in the according importer by dividing the timestamp value by 1000