### PR TITLE
Fix WP pre tag util raise error when value includes regexp

### DIFF
--- a/lib/jekyll-import/util.rb
+++ b/lib/jekyll-import/util.rb
@@ -32,7 +32,7 @@ module JekyllImport
           end
 
           name = "<pre wp-pre-tag-#{i}></pre>"
-          pre_tags[name] = pee_part[start..-1] + "</pre>"
+          pre_tags[name] = (pee_part[start..-1] + "</pre>").gsub('\\', '\\\\\\\\')
 
           pee += pee_part[0, start] + name
         end

--- a/test/test_util.rb
+++ b/test/test_util.rb
@@ -6,4 +6,10 @@ class TestUtil < Test::Unit::TestCase
     expected = "<p>this is a test</p>\n<p>and it works</p>\n"
     assert_equal(expected, Util.wpautop(original))
   end
+
+  should ".wpautop is escapes backslash" do
+    original = "<pre>/(?<word>\\w+) \\k<word>/</pre>"
+    expected = "<pre>/(?<word>\\w+) \\k<word>/</pre>\n"
+    assert_equal(expected, Util.wpautop(original))
+  end
 end


### PR DESCRIPTION
Fix Util#wpautop method to escape backslash.

`String#gsub!` requires escape backslash if second argument as String.
https://docs.ruby-lang.org/en/2.6.0/String.html#method-i-gsub