### PR TITLE
Re-introduce Ruby 2.3 support and test Jekyll 3.7+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.3
   Exclude:
     - docs/**/*
     - script/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.6
+  - &latest_ruby 2.6
   - 2.4
+  - 2.3
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
-    - JEKYLL_VERSION=3.7
+    - JEKYLL_VERSION="~> 3.8"
+matrix:
+  include:
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION="~> 3.7.4"
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
 before_install:
 - gem update --system
 before_script: bundle update

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@
 source "https://rubygems.org"
 gemspec
 
-gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}" if ENV["JEKYLL_VERSION"]
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
 gem "test-unit"

--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "jekyll-import/version"
 
 Gem::Specification.new do |s|
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.name    = "jekyll-import"
   s.version = JekyllImport::VERSION
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   # runtime dependencies
   s.add_runtime_dependency("fastercsv", "~> 1.0")
-  s.add_runtime_dependency("jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 3.7", "< 5.0")
+  s.add_runtime_dependency("jekyll", ">= 3.7", "< 5.0")
   s.add_runtime_dependency("nokogiri", "~> 1.0")
   s.add_runtime_dependency("reverse_markdown", "~> 1.0")
 


### PR DESCRIPTION
This plugin doesn't use Ruby 2.4 specific syntax and therefore we can relax the Ruby version constraint to the minimum testable version across the ecosystem: Ruby 2.3
Other changes include testing the plugin against jekyll 4.0 pre-release.