### PR TITLE
Extract encoded_content from feed

### DIFF
--- a/lib/jekyll-import/importers/rss.rb
+++ b/lib/jekyll-import/importers/rss.rb
@@ -57,11 +57,14 @@ module JekyllImport
             header[value] = item.send(value)
           end
 
-          output = ""
+          output = +""
 
           body.each do |row|
-            output += item.send(row)
+            output << item.send(row).to_s
           end
+
+          output.strip!
+          output = item.content_encoded if output.empty?
 
           FileUtils.mkdir_p("_posts")
 


### PR DESCRIPTION
### Summary
- Set `output` as `item.content_encoded` when `output` is an empty string.
- Ensure only *strings* are passed to be concatenated into the `output` string.

### Context
Closes #391 