### PR TITLE
Check whether option["tag"] is null or empty value

### DIFF
--- a/lib/jekyll-import/importers/rss.rb
+++ b/lib/jekyll-import/importers/rss.rb
@@ -51,7 +51,7 @@ module JekyllImport
             "title"  => item.title,
           }
 
-          header["tag"] = options["tag"] unless options.to_s.empty?
+          header["tag"] = options["tag"] unless (options["tag"].nil? || options["tag"].empty?)
 
           frontmatter.each do |value|
             header[value] = item.send(value)

--- a/lib/jekyll-import/importers/rss.rb
+++ b/lib/jekyll-import/importers/rss.rb
@@ -51,7 +51,7 @@ module JekyllImport
             "title"  => item.title,
           }
 
-          header["tag"] = options["tag"] unless (options["tag"].nil? || options["tag"].empty?)
+          header["tag"] = options["tag"] unless options["tag"].nil? || options["tag"].empty?
 
           frontmatter.each do |value|
             header[value] = item.send(value)


### PR DESCRIPTION
### Rationale

`option` is expected to be a Hash. Therefore `option.to_s` is never going to be empty since even `{}.to_s` equals `"{}"`. Tracing the git history of the line of code shows that this is probably an error during merge-resolution.
I'm opting to use the more verbose `options["tag"].nil? || options["tag"].empty?` instead of `options["tag"].to_s.empty?` since this conditional is inside an `#each` block. Using the latter format would result in unnecessary allocations of `""` when `options["tag"] == nil`