### PR TITLE
Fix wrong option in self.process_tags

### DIFF
--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -278,7 +278,7 @@ module JekyllImport
       end
 
       def self.process_tags(db, options, post)
-        return [] unless options[:categories]
+        return [] unless options[:tags]
 
         px = options[:table_prefix]
 


### PR DESCRIPTION
The method self.process_tags in s9y_database.rb wrongly checked the option :categories, likely due to a copy and paste error.

The fix is a one-liner