### PR TITLE
Pluxml

### DIFF
--- a/docs/_importers/pluxml.md
+++ b/docs/_importers/pluxml.md
@@ -12,8 +12,8 @@ To import your posts and drafts from a PluXML blog, run:
 {% highlight bash %}
 $ ruby -r rubygems -e 'require "jekyll-import";
     JekyllImport::Importers::Pluxml.run({
-      "source" => "/pluxml/data/articles"
-      "layout" => "your_layout"
+      "source" => "/pluxml/data/articles",
+      "layout" => "your_layout",
       "avoid_liquid" => TRUE
     })'
 {% endhighlight %}

--- a/docs/_importers/pluxml.md
+++ b/docs/_importers/pluxml.md
@@ -1,0 +1,22 @@
+---
+layout: docs
+title: PluXML
+prev_section: mt
+link_source:  pluxml
+next_section: posterous
+permalink: /docs/pluxml/
+---
+
+To import your posts and drafts from a PluXML blog, run:
+
+{% highlight bash %}
+$ ruby -r rubygems -e 'require "jekyll-import";
+    JekyllImport::Importers::Pluxml.run({
+      "source" => "/pluxml/data/articles"
+      "layout" => "your_layout"
+    })'
+{% endhighlight %}
+
+The `source` field is required.
+
+The `layout` field is optional, it will set the layout in each post and draft imported.

--- a/docs/_importers/pluxml.md
+++ b/docs/_importers/pluxml.md
@@ -14,9 +14,12 @@ $ ruby -r rubygems -e 'require "jekyll-import";
     JekyllImport::Importers::Pluxml.run({
       "source" => "/pluxml/data/articles"
       "layout" => "your_layout"
+      "avoid_liquid" => TRUE
     })'
 {% endhighlight %}
 
 The `source` field is required.
 
 The `layout` field is optional, it will set the layout in each post and draft imported.
+
+The `avoid_liquid` field is optional, it will add `render_with_liquid: false` option in the header of each file. Usefull if you have à lot of source code to show to your visitors.

--- a/lib/jekyll-import/importers/pluxml.rb
+++ b/lib/jekyll-import/importers/pluxml.rb
@@ -21,11 +21,13 @@ module JekyllImport
         if options["source"].nil?
           abort "Missing mandatory option --source."
         end
+	# no layout option, layout by default is post
         if options["layout"].nil?
           options["layout"] = "post"
         end
-        if !options["avoid_liquid"].nil?
-          options["avoid_liquid"] = true
+	# no avoid_liquid option, avoid_liquid by default is false
+        if options["avoid_liquid"].nil?
+          options["avoid_liquid"] = false
         end
       end
 
@@ -37,18 +39,22 @@ module JekyllImport
         FileUtils.mkdir_p("_posts")
         FileUtils.mkdir_p("_drafts")
 
+        # for each XML file in source location
         Dir.glob("*.xml", base: source).each do |df|
           df = File.join(source, df)
           filename = File.basename(df, ".*")
 
+          # prepare post file name in Jekyll format
           a_filename = filename.split('.')
           post_name  = a_filename.pop
           file_date  = a_filename.pop
           post_date  = file_date[0..3]+'-'+file_date[4..5]+'-'+file_date[6..7]
 
+          # if draft, only take post name
           if filename.split('.')[1].split(',')[0] == 'draft'
             directory = '_drafts'
             name      = "#{post_name}"
+          # if post, post date precede post name
           else
             directory = '_posts'
             name      = "#{post_date}-#{post_name}"

--- a/lib/jekyll-import/importers/pluxml.rb
+++ b/lib/jekyll-import/importers/pluxml.rb
@@ -1,0 +1,77 @@
+# Inspired by https://github.com/jekyll/jekyll-import/blob/v0.14.0/lib/jekyll-import/importers/rss.rb
+# Adapted for PluXML sources
+
+module JekyllImport
+  module Importers
+    class Pluxml < Importer
+      def self.require_deps
+        JekyllImport.require_with_fallback(%w(
+          nokogiri
+          fileutils
+          safe_yaml
+        ))
+      end
+
+      def self.specify_options(c)
+        c.option "source", "--source NAME", "The XML file to import"
+        c.option "layout", "--layout NAME", "The layout to apply"
+      end
+
+      def self.validate(options)
+        if options["source"].nil?
+          abort "Missing mandatory option --source."
+        end
+        if options["layout"].nil?
+          options["layout"] = "post"
+        end
+      end
+
+      def self.process(options)
+        source = options.fetch("source")
+        layout = options.fetch("layout")
+
+        FileUtils.mkdir_p("_posts")
+        FileUtils.mkdir_p("_drafts")
+
+        Dir.glob("*.xml", base: source).each do |df|
+          df = File.join(source, df)
+          filename = File.basename(df, ".*")
+          directory = if filename.split('.')[1].split(',')[0] == 'draft'
+                        '_drafts'
+                      else
+                        '_posts'
+                      end
+          a_filename = filename.split('.')
+          post_name = a_filename.pop
+          file_date = a_filename.pop
+          post_date = file_date[0..3]+'-'+file_date[4..5]+'-'+file_date[6..7]
+
+          xml = File.open(df) { |f| Nokogiri::XML(f) }
+
+          raise "There doesn't appear to be any XML items at the source (#{df}) provided." unless xml
+
+          doc = xml.xpath('document')
+          name = "#{post_date}-#{post_name}"
+
+          header = {
+            "layout" => layout,
+            "title"  => doc.xpath('title').text,
+            "tags"   => doc.xpath('tags').text,
+          }
+
+          path = File.join(directory, "#{name}.html")
+
+          File.open(path, "w") do |f|
+            f.puts header.to_yaml
+            f.puts "---\n\n"
+            f.puts doc.xpath('chapo').text
+            f.puts doc.xpath('content').text
+          end
+
+          puts "Writed file #{path} successfully!"
+        end
+        nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
PluXML is a blog CMS based on XML files instead of a database for articles and comments.
This script will help people to import their articles and drafts in Jekyll, with Nokogiri library.
I found some troubles with my own articles when you have source code in articles with a format similar to liquid, so I also include an option to tell Jekyll to not use the liquid render in exported files.