### PR TITLE
Fix 'can't add a new key into hash during iteration' error

### DIFF
--- a/lib/jekyll-import/importer.rb
+++ b/lib/jekyll-import/importer.rb
@@ -12,7 +12,7 @@ module JekyllImport
 
     def self.stringify_keys(hash)
       the_hash = hash.clone
-      the_hash.each_key do |key|
+      hash.each_key do |key|
         the_hash[(key.to_s rescue key) || key] = the_hash.delete(key)
       end
       the_hash


### PR DESCRIPTION
When I try to run:

```ruby
ruby -e 'require "jekyll-import";
    JekyllImport::Importers::WordPress.run({
    # . . .
    })'
```

Per the instructions found [here](https://import.jekyllrb.com/docs/wordpress/).

It throws this error:

```sh
Traceback (most recent call last):
	4: from -e:2:in `<main>'
	3: from /home/thestranjer/Code/jekyll-import/lib/jekyll-import/importer.rb:22:in `run'
	2: from /home/thestranjer/Code/jekyll-import/lib/jekyll-import/importer.rb:15:in `stringify_keys'
	1: from /home/thestranjer/Code/jekyll-import/lib/jekyll-import/importer.rb:15:in `each_key'
/home/thestranjer/Code/jekyll-import/lib/jekyll-import/importer.rb:16:in `block in stringify_keys': can't add a new key into hash during iteration (RuntimeError)
```

This is because in the `JekyllImport::Importer::stringify_keys` method, it is trying to edit the hash as it iterates over itself. This pull request fixes that.