### PR TITLE
WordpressDotCom: put downloaded assets into /year/month subfolders to reduce clashes

### DIFF
--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -192,7 +192,6 @@ module JekyllImport
             content = Hpricot(item.text_for("content:encoded"))
             header["excerpt"] = item.excerpt if item.excerpt
 
-
             # Put the images into a /yyyy/mm/ subfolder to reduce clashes
             assets_sub_folder = assets_folder
             if item.published_at

--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -173,7 +173,7 @@ module JekyllImport
             value = meta.at("wp:meta_value").inner_text
             metas[key] = value
           end
-          
+
           author_login = item.text_for("dc:creator").strip
 
           header = {

--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -33,10 +33,10 @@ module JekyllImport
           # Put the images into a /yyyy/mm/ subfolder to reduce clashes
           date_folder = published_at.strftime("/%Y/%m")
           assets_with_date_folder = format("%s%s", assets_folder, date_folder)
-          FileUtils.mkdir_p assets_withdate_folder
+          FileUtils.mkdir_p assets_with_date_folder
 
-          i["src"] = format("{{ site.baseurl }}/%s/%s", assets_withdate_folder, File.basename(uri))
-          dst = File.join(assets_withdate_folder, File.basename(uri))
+          i["src"] = format("{{ site.baseurl }}/%s/%s", assets_with_date_folder, File.basename(uri))
+          dst = File.join(assets_with_date_folder, File.basename(uri))
           Jekyll.logger.info uri
           if File.exist?(dst)
             Jekyll.logger.info "Already in cache. Clean assets folder if you want a redownload."

--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -31,8 +31,8 @@ module JekyllImport
           uri = i["src"]
 
           # Put the images into a /yyyy/mm/ subfolder to reduce clashes
-          datefolder = published_at.strftime("/%Y/%m")
-          assets_withdate_folder = format("%s%s", assets_folder, datefolder)
+          date_folder = published_at.strftime("/%Y/%m")
+          assets_with_date_folder = format("%s%s", assets_folder, date_folder)
           FileUtils.mkdir_p assets_withdate_folder
 
           i["src"] = format("{{ site.baseurl }}/%s/%s", assets_withdate_folder, File.basename(uri))

--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -35,8 +35,8 @@ module JekyllImport
           assets_with_date_folder = format("%s%s", assets_folder, date_folder)
           FileUtils.mkdir_p assets_with_date_folder
 
-          i["src"] = format("{{ site.baseurl }}/%s/%s", assets_with_date_folder, File.basename(uri))
           dst = File.join(assets_with_date_folder, File.basename(uri))
+          i["src"] = File.join("{{ site.baseurl }}", dst)
           Jekyll.logger.info uri
           if File.exist?(dst)
             Jekyll.logger.info "Already in cache. Clean assets folder if you want a redownload."

--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -192,14 +192,16 @@ module JekyllImport
             content = Hpricot(item.text_for("content:encoded"))
             header["excerpt"] = item.excerpt if item.excerpt
 
-            # Put the images into a /yyyy/mm/ subfolder to reduce clashes
-            assets_sub_folder = assets_folder
-            if item.published_at
-              date_folder = item.published_at.strftime("/%Y/%m")
-              assets_sub_folder = File.join(assets_folder, date_folder)
-            end
+            if fetch
+              # Put the images into a /yyyy/mm/ subfolder to reduce clashes
+              assets_dir_path = if item.published_at
+                                  File.join(assets_folder, item.published_at.strftime("/%Y/%m"))
+                                else
+                                  assets_folder
+                                end
 
-            download_images(item.title, content, assets_sub_folder) if fetch
+              download_images(item.title, content, assets_dir_path)
+            end
 
             FileUtils.mkdir_p item.directory_name
             File.open(File.join(item.directory_name, item.file_name), "w") do |f|


### PR DESCRIPTION
This PR resolves #435 

A small change to put downloaded assets into /year/month subfolder. This is done by using the date of the post as the subfolder in the assets folder. This keeps the assets chronologically with the post, and reduces clashes as this is the same as how Wordpress store their files.


**Before:**
When I ran the import tool on my blog, I had 350 clashes of images being overwritten.

**After:**
I successfully ran this on my blog https://DavidBurela.wordpress.com, which has 13 years, 230 posts. I only ended up with 5 clashes (which was due to me referencing images in other posts).


*Note:* I have never coded in Ruby before. I naively implemented it with the smallest number of changes that I could to reduce bugs. 