### PR TITLE
Clean up code to make Rubocop happy

### DIFF
--- a/lib/jekyll-import/importers/drupal6.rb
+++ b/lib/jekyll-import/importers/drupal6.rb
@@ -49,9 +49,7 @@ SQL
           "categories" => tags.split("|").uniq,
         }
 
-        if sql_post_data[:alias]
-          data["permalink"] = "/" + sql_post_data[:alias]
-        end
+        data["permalink"] = "/" + sql_post_data[:alias] if sql_post_data[:alias]
 
         [data, content]
       end

--- a/lib/jekyll-import/importers/rss.rb
+++ b/lib/jekyll-import/importers/rss.rb
@@ -31,9 +31,6 @@ module JekyllImport
       # Returns nothing.
       def self.process(options)
         source = options.fetch("source")
-        frontmatter = options.fetch("frontmatter", [])
-        body = options.fetch("body", ["description"])
-        render_audio = options.fetch("render_audio", false)
 
         content = ""
         open(source) { |s| content = s.read }
@@ -42,48 +39,56 @@ module JekyllImport
         raise "There doesn't appear to be any RSS items at the source (#{source}) provided." unless rss
 
         rss.items.each do |item|
-          formatted_date = item.date.strftime("%Y-%m-%d")
-          post_name = Jekyll::Utils.slugify(item.title, :mode => "latin")
-          name = "#{formatted_date}-#{post_name}"
-          audio = render_audio && item.enclosure.url
+          write_rss_item(item, options)
+        end
+      end
 
-          header = {
-            "layout" => "post",
-            "title"  => item.title,
-          }
+      def self.write_rss_item(item, options)
+        frontmatter = options.fetch("frontmatter", [])
+        body = options.fetch("body", ["description"])
+        render_audio = options.fetch("render_audio", false)
 
-          header["tag"] = options["tag"] unless options["tag"].nil? || options["tag"].empty?
+        formatted_date = item.date.strftime("%Y-%m-%d")
+        post_name = Jekyll::Utils.slugify(item.title, :mode => "latin")
+        name = "#{formatted_date}-#{post_name}"
+        audio = render_audio && item.enclosure.url
 
-          frontmatter.each do |value|
-            header[value] = item.send(value)
+        header = {
+          "layout" => "post",
+          "title"  => item.title,
+        }
+
+        header["tag"] = options["tag"] unless options["tag"].nil? || options["tag"].empty?
+
+        frontmatter.each do |value|
+          header[value] = item.send(value)
+        end
+
+        output = +""
+
+        body.each do |row|
+          output << item.send(row).to_s
+        end
+
+        output.strip!
+        output = item.content_encoded if output.empty?
+
+        FileUtils.mkdir_p("_posts")
+
+        File.open("_posts/#{name}.html", "w") do |f|
+          f.puts header.to_yaml
+          f.puts "---\n\n"
+
+          if audio
+            f.puts <<~HTML
+              <audio controls="">
+                <source src="#{audio}" type="audio/mpeg">
+                Your browser does not support the audio element.
+              </audio>
+            HTML
           end
 
-          output = +""
-
-          body.each do |row|
-            output << item.send(row).to_s
-          end
-
-          output.strip!
-          output = item.content_encoded if output.empty?
-
-          FileUtils.mkdir_p("_posts")
-
-          File.open("_posts/#{name}.html", "w") do |f|
-            f.puts header.to_yaml
-            f.puts "---\n\n"
-
-            if audio
-              f.puts <<~HTML
-                <audio controls="">
-                  <source src="#{audio}" type="audio/mpeg">
-                  Your browser does not support the audio element.
-                </audio>
-              HTML
-            end
-
-            f.puts output
-          end
+          f.puts output
         end
       end
     end

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -368,7 +368,7 @@ module JekyllImport
               attrs = get_media_attrs(iframe_node)
               media = "<iframe #{attrs}'></iframe>"
             else
-              STDERR.puts "Unrecognized media block: #{imgcaption}"
+              Jekyll.logger.warn "s9y database:", "Unrecognized media block: #{imgcaption}"
               return text
             end
           end

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -261,7 +261,7 @@ module JekyllImport
         require gem_name
         true
       rescue LoadError
-        warn "Could not require '#{gem_name}', so the :#{option_name} option is now disabled."
+        Jekyll.logger.warn "s9y database:", "Could not require '#{gem_name}', so the :#{option_name} option is now disabled."
         true
       end
 


### PR DESCRIPTION
```text
lib/jekyll-import/importers/drupal6.rb:52:9: C: Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||. (https://rubystyle.guide#if-as-a-modifier)
        if sql_post_data[:alias]
        ^^
lib/jekyll-import/importers/rss.rb:32:7: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for process is too high. [7/6]
      def self.process(options) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^
lib/jekyll-import/importers/rss.rb:44:9: C: Metrics/BlockLength: Block has too many lines. [32/25]
        rss.items.each do |item| ...
        ^^^^^^^^^^^^^^^^^^^^^^^^
lib/jekyll-import/importers/s9y_database.rb:371:15: C: Style/StderrPuts: Use warn instead of STDERR.puts to allow such output to be disabled. (https://rubystyle.guide#warn)
              STDERR.puts "Unrecognized media block: #{imgcaption}"
              ^^^^^^^^^^^
```