### PR TITLE
Update Enki website link

### DIFF
--- a/docs/_importers/enki.md
+++ b/docs/_importers/enki.md
@@ -7,7 +7,7 @@ next_section: ghost
 permalink: /docs/enki/
 ---
 
-To import your posts from a [Enki](http://enkiblog.com) installation, run:
+To import your posts from a [Enki](https://github.com/xaviershay/enki) installation, run:
 
 {% highlight bash %}
 $ ruby -r rubygems -e 'require "jekyll-import";


### PR DESCRIPTION
The enkiblog.com (content warning) domain hasn't been relevant to the blogging app since 2014.