### PR TITLE
Lock `rdoc` gem to v6.3.x to avoid Psych 4.0

### DIFF
--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   # development dependencies
   s.add_development_dependency("bundler")
   s.add_development_dependency("rake", "~> 12.0")
-  s.add_development_dependency("rdoc", "~> 6.0")
+  s.add_development_dependency("rdoc", "~> 6.3.0")
 
   # test dependencies:
   s.add_development_dependency("redgreen", "~> 1.2")


### PR DESCRIPTION
RDoc v6.4 has Psych v4 as a runtime dependency. Psych v4 breaks our CI running on Ruby 2.5
Therefore, restrain installation to rdoc-6.3.x until we stop testing with Ruby 2.5.