### PR TITLE
Add CI workflow job to print importer help info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,23 @@ jobs:
           bundler-cache: true
       - name: Run RuboCop
         run:  bash script/fmt
+
+  cli_help_check:
+    name: "CLI Help Info Check"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+          - 2.7
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 5
+      - name: "Set up Ruby ${{ matrix.ruby_version }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Print Importer Help Menus
+        run:  bundle exec ruby script/cli_help_check.rb

--- a/script/cli_help_check.rb
+++ b/script/cli_help_check.rb
@@ -1,0 +1,8 @@
+require "bundler/setup"
+require "jekyll-import"
+
+JekyllImport::Importer.subclasses.each do |importer|
+  name = importer.to_s.split("::").last.downcase
+  puts "\n\n"
+  system "jekyll", "import", name, "--help"
+end


### PR DESCRIPTION
To have a one-stop place to visualize what an end-user would see on invoking the help menu for desired importer.