### PR TITLE
Build and deploy docs site via GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,9 @@ on:
 
 env:
   RUBY_VERSION: 2.7
+  
+  # For control over build environment
+  DOCS_DEPLOY: true
 
 jobs:
   deploy_docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Build and deploy Documentation site
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  RUBY_VERSION: 2.7
+
+jobs:
+  deploy_docs:
+    runs-on: "ubuntu-latest"
+    env:
+      BUNDLE_PATH: "vendor/bundle"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - name: Clone target branch
+        run: |
+          REMOTE_BRANCH="${REMOTE_BRANCH:-gh-pages}"
+          REMOTE_REPO="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+
+          echo "Publishing to ${GITHUB_REPOSITORY} on branch ${REMOTE_BRANCH}"
+          rm -rf docs/_site/
+          git clone --depth=1 --branch="${REMOTE_BRANCH}" --single-branch --no-checkout \
+            "${REMOTE_REPO}" docs/_site/
+      - name: Build site
+        run: bundle exec jekyll build --source docs --destination docs/_site --verbose --trace
+      - name: Deploy to GitHub Pages
+        run: |
+          SOURCE_COMMIT="$(git log -1 --pretty="%an: %B" "$GITHUB_SHA")"
+          pushd docs/_site &>/dev/null
+          : > .nojekyll
+
+          git add --all
+          git -c user.name="${GITHUB_ACTOR}" -c user.email="${GITHUB_ACTOR}@users.noreply.github.com" \
+            commit --quiet \
+            --message "Deploy docs from ${GITHUB_SHA}" \
+            --message "$SOURCE_COMMIT"
+          git push
+
+          popd &>/dev/null


### PR DESCRIPTION
Similar to how the docs are deployed for the Jekyll Core repository.

## Rationale

- **Allow building with plugins to inject data at runtime.**
- Allow building with latest version of Jekyll.