### PR TITLE
Omit importer dependencies in docs-site workflow

### DIFF
--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -32,25 +32,32 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rake", "~> 13.0")
   s.add_development_dependency("rdoc", "~> 6.0")
 
-  # test dependencies:
-  s.add_development_dependency("redgreen", "~> 1.2")
-  s.add_development_dependency("rr", "~> 1.0")
-  s.add_development_dependency("rubocop-jekyll", "~> 0.11.0")
-  s.add_development_dependency("shoulda", "~> 4.0")
-  s.add_development_dependency("simplecov", "~> 0.7")
-  s.add_development_dependency("simplecov-gem-adapter", "~> 1.0")
+  # Dependencies not needed during building / deployment of the documentation site.
+  #
+  # Containing them within a conditional block in the gemspec instead of using a Bundler
+  # group in the Gemfile ensures that they remain listed in the page at Rubygems.org.
 
-  # migrator dependencies:
-  # s.add_development_dependency("behance", "~> 0.3") # uses outdated dependencies
-  s.add_development_dependency("hpricot", "~> 0.8")
-  s.add_development_dependency("htmlentities", "~> 4.3")
-  s.add_development_dependency("mysql2", "~> 0.3")
-  s.add_development_dependency("open_uri_redirections", "~> 0.2")
-  s.add_development_dependency("pg", "~> 1.0")
-  s.add_development_dependency("rss", "~> 0.2")
-  s.add_development_dependency("sequel", "~> 5.62")
-  s.add_development_dependency("sqlite3", "~> 1.3")
-  s.add_development_dependency("unidecode", "~> 1.0")
+  unless ENV["DOCS_DEPLOY"]
+    # test dependencies:
+    s.add_development_dependency("redgreen", "~> 1.2")
+    s.add_development_dependency("rr", "~> 1.0")
+    s.add_development_dependency("rubocop-jekyll", "~> 0.11.0")
+    s.add_development_dependency("shoulda", "~> 4.0")
+    s.add_development_dependency("simplecov", "~> 0.7")
+    s.add_development_dependency("simplecov-gem-adapter", "~> 1.0")
+
+    # importer dependencies:
+    # s.add_development_dependency("behance", "~> 0.3") # uses outdated dependencies
+    s.add_development_dependency("hpricot", "~> 0.8")
+    s.add_development_dependency("htmlentities", "~> 4.3")
+    s.add_development_dependency("mysql2", "~> 0.3")
+    s.add_development_dependency("open_uri_redirections", "~> 0.2")
+    s.add_development_dependency("pg", "~> 1.0")
+    s.add_development_dependency("rss", "~> 0.2")
+    s.add_development_dependency("sequel", "~> 5.62")
+    s.add_development_dependency("sqlite3", "~> 1.3")
+    s.add_development_dependency("unidecode", "~> 1.0")
+  end
 
   # site dependencies:
   s.add_development_dependency("launchy", "~> 2.4")

--- a/script/build-docs
+++ b/script/build-docs
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+
+export DOCS_DEPLOY=true
+buildopts="-s docs -d docs/_site"
+
+if [[ $# -lt 1 ]]; then
+  bundle exec jekyll build $buildopts
+else
+  bundle exec jekyll "$@" $buildopts
+fi


### PR DESCRIPTION
## Summary

Avoid installing importer dependencies and test-suite dependencies while building / deploying the documentation site.

## Background

While setting-up *Deploy Previews* (on `pull_request` events) for the docs-site via Netlify. the build-image there failed to install certain gems with native=extensions due to missing dependencies of the native-code compiler.

## Advantages

- Lesser number of gems to install.
- Using conditional block in the gemspec instead of a Bundler group in the Gemfile means dev-dependencies continue getting listed at the Rubygems.org page as is current behavior. 
