### PR TITLE
import command: sort list of importers when printing

### DIFF
--- a/lib/jekyll/commands/import.rb
+++ b/lib/jekyll/commands/import.rb
@@ -39,7 +39,7 @@ module Jekyll
               if args.empty?
                 Jekyll.logger.warn "You must specify an importer."
                 Jekyll.logger.info "Valid options are:"
-                importers.each { |i| Jekyll.logger.info "*", i.to_s }
+                importers.sort.each { |i| Jekyll.logger.info "*", i.to_s }
               end
             end
           end


### PR DESCRIPTION
After:

```console
jekyll import
You must specify an importer. 
 Valid options are: 
                  * behance
                  * blogger
                  * csv
                  * dotclear
                  * drupal6
                  * drupal7
                  * drupal8
                  * easyblog
                  * enki
                  * ghost
                  * googlereader
                  * joomla
                  * joomla3
                  * jrnl
                  * marley
                  * medium
                  * mephisto
                  * mt
                  * pluxml
                  * posterous
                  * roller
                  * rss
                  * s9y
                  * s9ydatabase
                  * textpattern
                  * tumblr
                  * typo
                  * wordpress
                  * wordpressdotcom
```