### PR TITLE
Update .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+---
+# Dependabot automatically keeps our packages up to date
+# Docs: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 99
+  reviewers:
+  - jekyll/plugin-core
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 99
+  reviewers:
+  - jekyll/plugin-core


### PR DESCRIPTION
Hey @jekyll/plugin-core!

There's been an update to the `.github/dependabot.yml` file template in jekyll/jekyllbot. This PR should bring this repo up to date.

Thanks! :revolving_hearts: :sparkles: :robot:
