### PR TITLE
For databases, especially mysql, connect over 127.0.0.1 IP address

### DIFF
--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -16,7 +16,7 @@ module JekyllImport
         DEFAULTS = {
           "engine"   => "mysql",
           "password" => "",
-          "host"     => "localhost",
+          "host"     => "127.0.0.1",
           "prefix"   => "",
           "port"     => "3306",
           "types"    => %w(blog story article),

--- a/lib/jekyll-import/importers/easyblog.rb
+++ b/lib/jekyll-import/importers/easyblog.rb
@@ -32,7 +32,7 @@ module JekyllImport
         dbname  = options.fetch("dbname")
         user    = options.fetch("user")
         pass    = options.fetch("password", "")
-        host    = options.fetch("host", "localhost")
+        host    = options.fetch("host", "127.0.0.1")
         section = options.fetch("section", "1")
         table_prefix = options.fetch("prefix", "jos_")
 

--- a/lib/jekyll-import/importers/joomla.rb
+++ b/lib/jekyll-import/importers/joomla.rb
@@ -33,7 +33,7 @@ module JekyllImport
         dbname  = options.fetch("dbname")
         user    = options.fetch("user")
         pass    = options.fetch("password", "")
-        host    = options.fetch("host", "localhost")
+        host    = options.fetch("host", "127.0.0.1")
         port    = options.fetch("port", 3306).to_i
         section = options.fetch("section", "1")
         table_prefix = options.fetch("prefix", "jos_")

--- a/lib/jekyll-import/importers/joomla3.rb
+++ b/lib/jekyll-import/importers/joomla3.rb
@@ -33,7 +33,7 @@ module JekyllImport
         dbname = options.fetch("dbname")
         user   = options.fetch("user")
         pass   = options.fetch("password", "")
-        host   = options.fetch("host", "localhost")
+        host   = options.fetch("host", "127.0.0.1")
         port   = options.fetch("port", 3306).to_i
         cid    = options.fetch("category", 0)
         table_prefix = options.fetch("prefix", "jos_")

--- a/lib/jekyll-import/importers/mephisto.rb
+++ b/lib/jekyll-import/importers/mephisto.rb
@@ -14,7 +14,7 @@ module JekyllImport
           COPY jekyll TO STDOUT WITH CSV HEADER;
           ROLLBACK;
         SQL
-        command = %(psql -h #{c[:host] || "localhost"} -c "#{sql.strip}" #{c[:database]} #{c[:username]} -o #{c[:filename] || "posts.csv"})
+        command = %(psql -h #{c[:host] || "127.0.0.1"} -c "#{sql.strip}" #{c[:database]} #{c[:username]} -o #{c[:filename] || "posts.csv"})
         Jekyll.logger.info "Executing:", command
         `#{command}`
         CSV.process
@@ -61,7 +61,7 @@ module JekyllImport
         dbname = options.fetch("dbname")
         user   = options.fetch("user")
         pass   = options.fetch("password", "")
-        host   = options.fetch("host", "localhost")
+        host   = options.fetch("host", "127.0.0.1")
 
         db = Sequel.mysql2(dbname, :user     => user,
                                    :password => pass,

--- a/lib/jekyll-import/importers/mt.rb
+++ b/lib/jekyll-import/importers/mt.rb
@@ -242,7 +242,7 @@ module JekyllImport
           Sequel.sqlite(dbname)
         when "mysql", "postgres"
           db_connect_opts = {
-            :host     => options.fetch("host", "localhost"),
+            :host     => options.fetch("host", "127.0.0.1"),
             :user     => options.fetch("user"),
             :password => options.fetch("password", ""),
           }

--- a/lib/jekyll-import/importers/roller.rb
+++ b/lib/jekyll-import/importers/roller.rb
@@ -64,7 +64,7 @@ module JekyllImport
         options = {
           :user           => opts.fetch("user", ""),
           :pass           => opts.fetch("password", ""),
-          :host           => opts.fetch("host", "localhost"),
+          :host           => opts.fetch("host", "127.0.0.1"),
           :port           => opts.fetch("port", "3306"),
           :socket         => opts.fetch("socket", nil),
           :dbname         => opts.fetch("dbname", ""),

--- a/lib/jekyll-import/importers/s9y_database.rb
+++ b/lib/jekyll-import/importers/s9y_database.rb
@@ -99,7 +99,7 @@ module JekyllImport
         options = {
           :user              => opts.fetch("user", ""),
           :pass              => opts.fetch("password", ""),
-          :host              => opts.fetch("host", "localhost"),
+          :host              => opts.fetch("host", "127.0.0.1"),
           :port              => opts.fetch("port", 3306),
           :socket            => opts.fetch("socket", nil),
           :dbname            => opts.fetch("dbname", ""),

--- a/lib/jekyll-import/importers/textpattern.rb
+++ b/lib/jekyll-import/importers/textpattern.rb
@@ -37,7 +37,7 @@ module JekyllImport
         dbname = options.fetch("dbname")
         user   = options.fetch("user")
         pass   = options.fetch("password", "")
-        host   = options.fetch("host", "localhost")
+        host   = options.fetch("host", "127.0.0.1")
 
         db = Sequel.mysql2(dbname, :user => user, :password => pass, :host => host, :encoding => "utf8")
 

--- a/lib/jekyll-import/importers/typo.rb
+++ b/lib/jekyll-import/importers/typo.rb
@@ -43,7 +43,7 @@ module JekyllImport
         dbname = options.fetch("dbname")
         user   = options.fetch("user")
         pass   = options.fetch("password", "")
-        host   = options.fetch("host", "localhost")
+        host   = options.fetch("host", "127.0.0.1")
 
         FileUtils.mkdir_p "_posts"
         case server.intern

--- a/lib/jekyll-import/importers/wordpress.rb
+++ b/lib/jekyll-import/importers/wordpress.rb
@@ -81,7 +81,7 @@ module JekyllImport
         options = {
           :user           => opts.fetch("user", ""),
           :pass           => opts.fetch("password", ""),
-          :host           => opts.fetch("host", "localhost"),
+          :host           => opts.fetch("host", "127.0.0.1"),
           :port           => opts.fetch("port", "3306"),
           :socket         => opts.fetch("socket", nil),
           :dbname         => opts.fetch("dbname", ""),


### PR DESCRIPTION
When using 'localhost', mysql2 uses the socket. This is an uncommon setup, so use IP instead.

Fixes #478.