### PR TITLE
Escape non ascii-characters while image downlading from wordpress

### DIFF
--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -28,7 +28,7 @@ module JekyllImport
 
         Jekyll.logger.info "Downloading images for ", title
         images.each do |i|
-          uri = URI::Parser.new.escape(i["src"])
+          uri = URI::DEFAULT_PARSER.escape(i["src"])
 
           dst = File.join(assets_folder, File.basename(uri))
           i["src"] = File.join("{{ site.baseurl }}", dst)

--- a/lib/jekyll-import/importers/wordpressdotcom.rb
+++ b/lib/jekyll-import/importers/wordpressdotcom.rb
@@ -28,7 +28,7 @@ module JekyllImport
 
         Jekyll.logger.info "Downloading images for ", title
         images.each do |i|
-          uri = i["src"]
+          uri = URI::Parser.new.escape(i["src"])
 
           dst = File.join(assets_folder, File.basename(uri))
           i["src"] = File.join("{{ site.baseurl }}", dst)


### PR DESCRIPTION
While importing one of the Turkish websites, I noticed ruby HTTP library was not able to download because of the non-ASCII characters.

So I used escape while download process.

An example command

```bash
ruby -r rubygems -e 'require "jekyll-import";JekyllImport::Importers::WordpressDotCom.run({"source" => "wordpress.xml","no_fetch_images" => false, "assets_folder" => "assets" })'
```