### PR TITLE
Add jekyll-import command

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ The new __Jekyll__ command for importing from various blogs to Jekyll format.
 ### Jekyll v2.x and higher
 
 1. Install the _rubygem_ with `gem install jekyll-import`.
-2. Run `jekyll import IMPORTER [options]`
+2. Run `jekyll-import IMPORTER [options]`
 
 ### Jekyll v1.x
 

--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -15,7 +15,7 @@ Found an issue with one of the importers? Sorry about that! In order to better a
 1. Collection information about your system: operating system and version, Ruby version, Jekyll version, jekyll-import version.
 2. Which importer are you using? Note this.
 3. Collect the relevant data. This may be data from your database or input file. This will help us diagnose where the issue occurred.
-4. Ensure the `--trace` option is specified if you're running `jekyll import` from the command-line.
+4. Ensure the `--trace` option is specified if you're running `jekyll-import` from the command-line.
 4. [Open a new issue]({{ site.repository }}/issues/new) describing the four above points, as well as what you expected the outcome of your incantation to be.
 
 You should receive help soon. As always, check out [our help repo](https://talk.jekyllrb.com/) if you just have a question.
@@ -90,5 +90,5 @@ Once you have your importer working (test with `script/console`), then you're re
 `./docs/_importers/columbus.md`. Take a look at one of the other importers as an example. You just add basic usage and you're golden.
 
 All set? Add everything to a branch on your fork of `jekyll-import` and
-[submit a pull request](https://github.com/jekyll/jekyll-import/compare/).  
+[submit a pull request](https://github.com/jekyll/jekyll-import/compare/).
 Thank you!

--- a/docs/_layouts/importer.html
+++ b/docs/_layouts/importer.html
@@ -20,7 +20,7 @@ layout: docs
 
 <p>
   Sample snippet to invoke the importer:
-  <pre>jekyll import {{ page.cmd_name }}{% if page.cmd_opts %} {{ page.cmd_opts | map: 'switch' | join: ' ' }}{% endif %}</pre>
+  <pre>jekyll-import {{ page.cmd_name }}{% if page.cmd_opts %} {{ page.cmd_opts | map: 'switch' | join: ' ' }}{% endif %}</pre>
 </p>
 
 <div class="table-container">

--- a/exe/jekyll-import
+++ b/exe/jekyll-import
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+STDOUT.sync = true
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require 'jekyll-import'
+require 'jekyll/commands/import'
+require 'mercenary'
+
+Mercenary.program(:jekyll_import) do |p|
+  p.version JekyllImport::VERSION
+  p.description "Import from various blogs to Jekyll format."
+  p.syntax "jekyll-import <blog_engine> [options]"
+
+  # Create all the subcommands for the importers.
+  JekyllImport.add_importer_commands(p)
+
+  p.action do |args, _|
+    if args.empty?
+      Jekyll.logger.error "An importer subcommand is required."
+      puts p
+      abort
+    else
+      subcommand = args.first
+      unless p.has_command? subcommand
+        Jekyll.logger.abort_with "fatal: 'jekyll-import #{args.first}'" \
+          " could not be found."
+      end
+    end
+  end
+end

--- a/jekyll-import.gemspec
+++ b/jekyll-import.gemspec
@@ -16,7 +16,10 @@ Gem::Specification.new do |s|
   s.email    = "maintainers@jekyllrb.com"
   s.homepage = "http://github.com/jekyll/jekyll-import"
 
-  s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(%r!^lib/!)
+  all_files       = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  s.files         = all_files.grep(%r!^(exe|lib|rubocop)/|^.rubocop.yml$!)
+  s.executables   = all_files.grep(%r!^exe/!) { |f| File.basename(f) }
+  s.bindir        = "exe"
   s.require_paths = %w(lib)
 
   s.rdoc_options = ["--charset=UTF-8"]


### PR DESCRIPTION
We have been asking folks to run `jekyll import` for a while, but it requires a `Gemfile`. Not everyone wants to have a Gemfile or knows how to set one up. I'd like to be a bit more independent of Jekyll and its not-always-entirely-working system for external subcommands.

This commit adds a new top-level 'jekyll-import' command so that this gem can handle importing without requiring a Gemfile with `:jekyll_plugins`.

The flow is still rather tedious:

1. Run `jekyll-import` to see subcommands
2. Run `jekyll-import <subcommand> --help` to see options
3. Run `jekyll-import <subcommand> <options>` but get a dependency-not-found error
4. Run `gem install <dependency1>` to install
5. Re-run `jekyll-import <subcommand> <options>` but get another dependency-not-found error.
6. Run `gem install <dependency_N>` to install. Repeat 5 and 6 until all dependencies are satisfied.
7. Finally, re-run `jekyll-import <subcommand> <options>` and observe your output site (assuming to bugs in the importer)

Fixes #530.