### PR TITLE
Require jekyll-import/version so JekyllImport::VERSION can be read.

### DIFF
--- a/exe/jekyll-import
+++ b/exe/jekyll-import
@@ -6,6 +6,7 @@ STDOUT.sync = true
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require 'jekyll-import'
+require 'jekyll-import/version'
 require 'jekyll/commands/import'
 require 'mercenary'
 

--- a/exe/jekyll-import
+++ b/exe/jekyll-import
@@ -5,10 +5,10 @@ STDOUT.sync = true
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
-require 'jekyll-import'
-require 'jekyll-import/version'
-require 'jekyll/commands/import'
-require 'mercenary'
+require "jekyll-import"
+require "jekyll-import/version"
+require "jekyll/commands/import"
+require "mercenary"
 
 Mercenary.program(:jekyll_import) do |p|
   p.version JekyllImport::VERSION


### PR DESCRIPTION
Fixes #535.