### PR TITLE
docs: update latest release to 0.24.0

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,7 +5,7 @@ relative_permalinks: false
 permalink: /news/:year/:month/:day/:title/
 excerpt_separator: ""
 repository: https://github.com/jekyll/jekyll-import
-latest_release: 0.14.0
+latest_release: 0.24.0
 
 collections:
   docs:


### PR DESCRIPTION
Hi,

while browsing https://import.jekyllrb.com/docs/wordpress/ I realized [View Source](https://github.com/jekyll/jekyll-import/blob/v0.14.0/lib/jekyll-import/importers/wordpress.rb) on that page is a little out of date.

Here's a possible fix.

Another option would be to point to latest tip of tree, e.g. https://github.com/jekyll/jekyll-import/blob/master/lib/jekyll-import/importers/wordpress.rb

by changing https://github.com/jekyll/jekyll-import/blob/d332fa22c68c9e0fc1149f0579f017c659130e37/docs/_layouts/docs.html#L42

Have a nice week
midzer