### PR TITLE
550 drupal 7 does not import author name email

### DIFF
--- a/lib/jekyll-import/importers/drupal7.rb
+++ b/lib/jekyll-import/importers/drupal7.rb
@@ -34,10 +34,14 @@ SQL
                        n.created,
                        n.status,
                        n.type,
+                       u.name,
+                       u.mail,
                        #{tag_group}
                 FROM #{prefix}node AS n
                 LEFT JOIN #{prefix}field_data_body AS fdb
                   ON fdb.entity_id = n.nid AND fdb.entity_type = 'node'
+                RIGHT JOIN #{prefix}users AS u
+                  ON u.uid = n.uid
                 WHERE (#{types})
 QUERY
 

--- a/lib/jekyll-import/importers/drupal8.rb
+++ b/lib/jekyll-import/importers/drupal8.rb
@@ -34,10 +34,14 @@ SQL
                        n.created,
                        n.status,
                        n.type,
+                       u.name,
+                       u.mail,
                        #{tag_group}
                 FROM #{prefix}node_field_data AS n
                 LEFT JOIN #{prefix}node__body AS nb
                   ON nb.entity_id = n.nid
+                RIGHT JOIN #{prefix}users AS u
+                  ON u.uid = n.uid
                 WHERE (#{types})
 QUERY
 

--- a/lib/jekyll-import/importers/drupal_common.rb
+++ b/lib/jekyll-import/importers/drupal_common.rb
@@ -98,6 +98,8 @@ module JekyllImport
             data, content = post_data(post)
 
             data["layout"] = post[:type]
+            data["name"] = post[:name]
+            data["mail"] = post[:mail]
             title = data["title"] = post[:title].strip.force_encoding("UTF-8")
             time = data["created"] = post[:created]
 


### PR DESCRIPTION
Fixes #550.

While the issue was written up for Drupal 7, I realized that the drupal7 and drupal8 importers share a common file.  I believe this approach should work for Drupal 8 as well, and it's reasonable to assume that users would want author name and email supported in both versions.

As mentioned in the issue description, I could use some guidance on how to test this.  Or, provide a build and I'll be the guinea pig!  (For Drupal 7 at least.)